### PR TITLE
➖ replace `big-integer` with native `BigInt`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.3.13",
+      "name": "steam-rom-manager",
+      "version": "2.3.15",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
@@ -25,7 +26,6 @@
         "ajv": "^6.4.0",
         "appid": "^1.0.3",
         "async": "^2.6.0",
-        "big-integer": "https://github.com/cbartondock/BigInteger.js.git",
         "binary-vdf": "^0.1.0",
         "blob-to-buffer": "^1.2.7",
         "bluebird": "^3.5.1",
@@ -1370,8 +1370,6 @@
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
         "fs-extra": "^8.1.0",
-        "global-agent": "^2.0.2",
-        "global-tunnel-ng": "^2.7.1",
         "got": "^9.6.0",
         "progress": "^2.0.3",
         "sanitize-filename": "^1.6.2",
@@ -2770,12 +2768,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "node_modules/big-integer": {
-      "resolved": "git+ssh://git@github.com/cbartondock/BigInteger.js.git#7cb23ce2a2ef838f0420bc0abe1ad25207301071",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -3423,7 +3415,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.0",
         "braces": "^2.3.0",
-        "fsevents": "^1.1.2",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
@@ -13774,12 +13765,8 @@
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
         "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "getpass": "^0.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -14977,7 +14964,6 @@
       "dev": true,
       "dependencies": {
         "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
         "yargs": "~3.10.0"
       },
       "bin": {
@@ -18490,10 +18476,6 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "big-integer": {
-      "version": "git+ssh://git@github.com/cbartondock/BigInteger.js.git#7cb23ce2a2ef838f0420bc0abe1ad25207301071",
-      "from": "big-integer@https://github.com/cbartondock/BigInteger.js.git"
     },
     "big.js": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "ajv": "^6.4.0",
     "appid": "^1.0.3",
     "async": "^2.6.0",
-    "big-integer": "https://github.com/cbartondock/BigInteger.js.git",
     "binary-vdf": "^0.1.0",
     "blob-to-buffer": "^1.2.7",
     "bluebird": "^3.5.1",

--- a/src/lib/helpers/steam/generate-app-id.ts
+++ b/src/lib/helpers/steam/generate-app-id.ts
@@ -1,25 +1,24 @@
 import * as crc from 'crc';
-import * as BigInt from 'big-integer';
 
 export function generateAppId(exe: string, name: string) {
   const key = exe + name;
-  const top = BigInt(crc.crc32(key)).or(BigInt(0x80000000));
-  const bigint = BigInt(top).shiftLeft(32).or(BigInt(0x02000000));
+  const top = BigInt(crc.crc32(key)) | BigInt(0x80000000);
+  const bigint = BigInt(top) << BigInt(32) | BigInt(0x02000000);
   return String(bigint);
 }
 
 export function generateShortAppId(exe: string, name: string) {
     const key = exe + name;
-    const top = BigInt(crc.crc32(key)).or(BigInt(0x80000000));
-    const bigint = BigInt(top).shiftLeft(32).or(BigInt(0x02000000));
-    const shift = BigInt(bigint).shiftRight(32);
+    const top = BigInt(crc.crc32(key)) | BigInt(0x80000000);
+    const bigint = BigInt(top) << BigInt(32) | BigInt(0x02000000);
+    const shift = BigInt(bigint) >> BigInt(32);
     return String(shift);
 }
 
 export function shortenAppId(appid: string) {
-  return String(BigInt(appid).shiftRight(32));
+  return String(BigInt(appid) >> BigInt(32));
 }
 
 export function lengthenAppId(appid: string) {
-  return String(BigInt(appid).shiftLeft(32).or(BigInt(0x02000000)));
+  return String(BigInt(appid) << BigInt (32) | BigInt(0x02000000));
 }

--- a/src/lib/helpers/steam/generate-app-id.ts
+++ b/src/lib/helpers/steam/generate-app-id.ts
@@ -20,5 +20,5 @@ export function shortenAppId(appid: string) {
 }
 
 export function lengthenAppId(appid: string) {
-  return String(BigInt(appid) << BigInt (32) | BigInt(0x02000000));
+  return String(BigInt(appid) << BigInt(32) | BigInt(0x02000000));
 }


### PR DESCRIPTION
NodeJS has `BigInt` support since v10.4.0 and using the native version will avoid this TS error during `npm run build:dist`:

```
ERROR in [at-loader] ./node_modules/big-integer/BigInteger.d.ts:7:8 
    TS2457: Type alias name cannot be 'bigint'.
```