### PR TITLE
Address feedback from PR 761

### DIFF
--- a/ALTERNATIVE_LSOF_APPROACH.md
+++ b/ALTERNATIVE_LSOF_APPROACH.md
@@ -1,0 +1,89 @@
+# Alternative Approach: Using lsof to Check File Locks
+
+If checking only the main `steam` process isn't sufficient, here's an alternative approach that checks which processes actually have the category storage files open:
+
+## Implementation
+
+```typescript
+// In stop-start-steam.ts, replace the Linux stopSteam check with:
+
+} else if (os.type() == "Linux") {
+  data.commands = {
+    action: `kill -15 $(pidof -x steam) 2>/dev/null || true`,
+    check: `
+      # Find steam directory from common locations
+      STEAM_DIR=""
+      if [ -d "$HOME/.steam/steam" ]; then
+        STEAM_DIR="$HOME/.steam/steam"
+      elif [ -d "$HOME/.local/share/Steam" ]; then
+        STEAM_DIR="$HOME/.local/share/Steam"
+      fi
+
+      if [ -z "$STEAM_DIR" ]; then
+        # Can't find steam dir, just check for steam process
+        steam_pid=$(pgrep -x '^steam$' 2>/dev/null)
+        if [ -z "$steam_pid" ]; then echo "True"; else echo "False"; fi
+      else
+        # Check if any process has the category files open
+        # Check cloud storage, localconfig.vdf, or leveldb files
+        CLOUD_FILES=$(find "$STEAM_DIR/userdata/*/config/cloudstorage" -name "cloud-storage-namespace-*.json" 2>/dev/null)
+        LOCALCONFIG_FILES=$(find "$STEAM_DIR/userdata/*/config" -name "localconfig.vdf" 2>/dev/null)
+        LEVELDB_DIR="$STEAM_DIR/config/htmlcache/Local Storage/leveldb"
+
+        HAS_LOCKS=0
+
+        # Check cloud storage files
+        for file in $CLOUD_FILES; do
+          if lsof "$file" 2>/dev/null | grep -q .; then
+            HAS_LOCKS=1
+            break
+          fi
+        done
+
+        # Check localconfig.vdf files
+        if [ $HAS_LOCKS -eq 0 ]; then
+          for file in $LOCALCONFIG_FILES; do
+            if lsof "$file" 2>/dev/null | grep -q .; then
+              HAS_LOCKS=1
+              break
+            fi
+          done
+        fi
+
+        # Check leveldb directory
+        if [ $HAS_LOCKS -eq 0 ] && [ -d "$LEVELDB_DIR" ]; then
+          if lsof +D "$LEVELDB_DIR" 2>/dev/null | grep -q .; then
+            HAS_LOCKS=1
+          fi
+        fi
+
+        if [ $HAS_LOCKS -eq 0 ]; then
+          echo "True"
+        else
+          echo "False"
+        fi
+      fi
+    `.trim(),
+  };
+  data.shell = "/bin/sh";
+}
+```
+
+## Pros
+- Most accurate - checks actual file locks
+- Won't have false positives from unrelated Steam processes
+- Works regardless of Steam's internal process architecture
+
+## Cons
+- More complex
+- Requires `lsof` to be installed (usually is on Linux)
+- Slower due to file system checks
+- May require permissions to check file locks
+
+## Recommendation
+
+**Start with the simple approach (only checking main steam process)** and only implement this if you find that:
+1. Helper processes actually do hold the files open
+2. Users report write failures when they shouldn't happen
+
+The simple approach is cleaner, faster, and aligns with the CLAUDE.md documentation which states that only the main `steam` process and `steamwebhelper` hold category files - and we now know `steamwebhelper` is just for web rendering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Ability to drag/drop to re-arrange parsers in Classic and Deck themes.
-- Several UI standardizations: Unified color scheme for Deck theme, moved 
-logger options to an options panel, minimized all docs by default, minimized error reporter by default.
+- Several UI standardizations: Unified color scheme for Deck theme, moved
+  logger options to an options panel, minimized all docs by default, minimized error reporter by default.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,150 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Steam ROM Manager (SRM) is an Electron application built with Angular that manages ROMs and non-Steam games in Steam. It automatically adds games to Steam libraries with artwork, controller templates, and proper categorization.
+
+## Development Commands
+
+### Essential Commands
+- `yarn install` - Install dependencies (run after cloning)
+- `yarn run build:dist` - Build both main and renderer processes for production
+- `yarn run start` - Launch the compiled application
+- `yarn run watch:main` - Watch and recompile main Electron process
+- `yarn run watch:renderer` - Watch and recompile Angular renderer process
+- `yarn run pretty:check` - Check code formatting with Prettier
+- `yarn run pretty:write` - Auto-format code with Prettier
+
+### Building for Distribution
+- `yarn run build:win` - Build Windows installer/portable
+- `yarn run build:linux` - Build Linux deb package and AppImage
+- `yarn run build:mac` - Build macOS dmg package
+
+### Development Workflow
+1. Run `yarn run watch:main` once (rarely changes)
+2. Run `yarn run watch:renderer` for ongoing development
+3. Use `yarn run start` to launch the app
+4. Refresh with Ctrl+R after renderer changes
+5. Restart app after main process changes
+
+## Architecture
+
+### Main Process (`src/main/`)
+- **app.ts** - Electron main process with CLI interface, crash reporting, auto-updater
+- Handles window management, IPC communication, and system integration
+
+### Renderer Process (`src/renderer/`)
+- **Angular 18** application with TypeScript
+- **app.module.ts** - Main Angular module configuration
+- **components/** - UI components organized by feature
+- **services/** - Data services and business logic
+- **templates/** - HTML templates for components
+- **styles/** - SCSS stylesheets
+
+### Core Libraries (`src/lib/`)
+- **parsers/** - Game/ROM parsers for different platforms (Steam, Epic, GOG, emulators)
+  - Each parser implements specific platform logic
+  - Support for both ROM files and digital store libraries
+- **vdf-manager.ts** - Steam VDF file manipulation
+- **category-manager.ts** - Steam category management
+- **controller-manager.ts** - Controller template handling
+- **image-provider.ts** - Artwork fetching and caching
+- **file-parser.ts** - File system parsing and glob matching
+
+### Parser System
+The parser architecture supports multiple game sources:
+- **ROM Parsers**: glob, glob-regex, manual
+- **Platform Parsers**: Steam, Epic, GOG, EA Desktop, Amazon Games, Ubisoft Connect, etc.
+- **Artwork Parsers**: Steam games, non-SRM shortcuts
+
+### Steam Category Storage System
+
+SRM writes category data to three storage locations in priority order (newest to oldest):
+
+1. **Cloud Storage** (Primary/Modern - Steam Deck default):
+   - `~/.steam/steam/userdata/<userid>/config/cloudstorage/cloud-storage-namespace-*.json`
+   - Synced across devices
+   - SRM writes to ONE system only, stopping after first success
+
+2. **localconfig.vdf** (Fallback):
+   - `~/.steam/steam/userdata/<userid>/config/localconfig.vdf`
+   - Traditional Steam configuration file
+
+3. **leveldb** (Legacy):
+   - `~/.steam/steam/config/htmlcache/Local Storage/leveldb/*.ldb`
+   - Browser storage used by older Steam versions
+
+**Read Priority**: Cloud storage → localconfig.vdf → leveldb
+**Write Strategy**: Try cloud storage first; if it fails, fall back to localconfig.vdf, then leveldb as last resort
+
+### Steam Process Management
+
+When auto-kill Steam is enabled, SRM needs to detect when Steam processes are fully stopped:
+
+**Process checked on Linux/Steam Deck**:
+- `steam` - Main Steam client process
+
+**Important findings from testing**:
+- Steam does NOT keep category files locked - it reads/writes them transiently
+- Files can technically be written while Steam is running, BUT:
+  - Race condition risk if Steam writes at the same moment
+  - Steam caches category data in memory and won't see changes until restart
+  - Therefore, killing Steam before writes is the safest approach
+
+**Not checked** (these don't prevent category file operations):
+- `steamwebhelper` - Web rendering helper (never holds category files)
+- `reaper` - Game process manager (doesn't hold category files)
+- `steamos-manager` - System daemon (not part of Steam client)
+- `fossilize_replay` - Background shader compiler (doesn't prevent operations)
+
+**Detection uses exact matching** (`pgrep -x '^steam$'`) to avoid matching SRM's own process name.
+
+### Configuration
+- **TypeScript**: ES2022 target with Angular decorators
+- **Webpack**: Separate configs for main/renderer processes
+- **Electron Builder**: Multi-platform distribution
+- **Prettier**: Code formatting with auto end-of-line
+
+### Key Technologies
+- Electron 32+ with remote module
+- Angular 18 with RxJS
+- Node.js file system operations
+- Steam VDF format parsing
+- SQLite for local data storage
+- SteamGridDB API integration
+
+## Testing and Quality
+
+The project uses:
+- TypeScript strict mode with noImplicitAny
+- Prettier for code formatting
+- Electron Builder for consistent builds
+- Native module recompilation via postinstall
+
+## CLI Interface
+
+SRM includes a full CLI with commands like:
+- `list` - Show all parsers and status
+- `add` - Add games to Steam
+- `remove` - Remove games from Steam
+- Multiple parser-specific options and flags
+
+## Important Notes
+
+### Steam Process Detection
+- Always use exact process name matching to avoid false positives
+- SRM's process name may contain "steam" - ensure checks use `pgrep -x` with regex anchors
+- Only check processes that actually hold category storage files open
+
+### Category File Operations
+- Priority order: cloud storage → localconfig.vdf → leveldb
+- Write to ONE system only (stop after first success)
+- Graceful error handling at each level
+- Steam must be fully stopped before writing
+
+### Auto-Restart Behavior
+- If `autoRestartSteam` is ON: Steam restarts immediately after save
+- If `autoRestartSteam` is OFF but Steam was killed: Steam restarts when SRM exits
+- Prevents leaving users with Steam permanently closed

--- a/files/presets/Nintendo 64.json
+++ b/files/presets/Nintendo 64.json
@@ -449,172 +449,156 @@
     "drmProtect": false,
     "steamCategories": ["N64"]
   },
-	"Nintendo 64 - Rosalie's Mupen GUI": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo 64 - Rosalie's Mupen GUI",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --nogui --quit-after-emulation \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.n64|.N64|.v64|.V64|.z64|.Z64|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-RMG",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"N64"
-		]
-	},
-	"Nintendo 64 - Rosalie's Mupen GUI(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo 64 - Rosalie's Mupen GUI(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run com.github.Rosalie241.RMG --fullscreen --nogui --quit-after-emulation \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.n64|.N64|.v64|.V64|.z64|.Z64|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"N64"
-		]
-	},
+  "Nintendo 64 - Rosalie's Mupen GUI": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo 64 - Rosalie's Mupen GUI",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --nogui --quit-after-emulation \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.n64|.N64|.v64|.V64|.z64|.Z64|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-RMG",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["N64"]
+  },
+  "Nintendo 64 - Rosalie's Mupen GUI(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo 64 - Rosalie's Mupen GUI(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run com.github.Rosalie241.RMG --fullscreen --nogui --quit-after-emulation \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.n64|.N64|.v64|.V64|.z64|.Z64|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["N64"]
+  },
   "Nintendo 64 - simple64(Flatpak)": {
     "parserType": "Glob",
     "configTitle": "Nintendo 64 - simple64(Flatpak)",

--- a/files/presets/Sony PlayStation.json
+++ b/files/presets/Sony PlayStation.json
@@ -450,87 +450,77 @@
     "steamCategories": ["PS1"]
   },
   "Sony PlayStation - Retroarch - SwanStation": {
-		"parserType": "Glob",
-		"configTitle": "Sony PlayStation - Retroarch - SwanStation",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}swanstation_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
-		"onlineImageQueries": [
-			"${fuzzyTitle}"
-		],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.chd|.CHD|.cue|.CUE|.ecm|.ECM|.exe|.EXE|.img|.IMG|.iso|.ISO|.m3u|.M3U|.mds|.MDS|.pbp|.PBP|.psexe|.PSEXE|.psf|.PSF)"
-		},
-		"titleFromVariable": {
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false,
-			"limitToGroups": []
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "${retroarchpath}",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 19,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"PS1"
-		]
-	}
+    "parserType": "Glob",
+    "configTitle": "Sony PlayStation - Retroarch - SwanStation",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "-L ${os:win|cores|${os:mac|${racores}|${os:linux|${racores}}}}${/}swanstation_libretro.${os:win|dll|${os:mac|dylib|${os:linux|so}}} \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.chd|.CHD|.cue|.CUE|.ecm|.ECM|.exe|.EXE|.img|.IMG|.iso|.ISO|.m3u|.M3U|.mds|.MDS|.pbp|.PBP|.psexe|.PSEXE|.psf|.PSF)"
+    },
+    "titleFromVariable": {
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false,
+      "limitToGroups": []
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "${retroarchpath}",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 19,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      }
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["PS1"]
+  }
 }

--- a/files/presets/ares.json
+++ b/files/presets/ares.json
@@ -1,4152 +1,3752 @@
 {
-	"Atari 2600 - ares": {
-		"parserType": "Glob",
-		"configTitle": "Atari 2600 - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Atari 2600\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.a26|.A26|.bin|.BIN|.rom|.ROM|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"2600"
-		]
-	},
-	"Atari 2600 - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Atari 2600 - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Atari 2600\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.a26|.A26|.bin|.BIN|.rom|.ROM|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"2600"
-		]
-	},
-	"Bandai WonderSwan Color - ares": {
-		"parserType": "Glob",
-		"configTitle": "Bandai WonderSwan Color - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"WonderSwan Color\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Wanderswan Color"
-		]
-	},
-	"Bandai WonderSwan Color - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Bandai WonderSwan Color - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"WonderSwan Color\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Wanderswan Color"
-		]
-	},
-	"Bandai WonderSwan - ares": {
-		"parserType": "Glob",
-		"configTitle": "Bandai WonderSwan - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"WonderSwan\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Wanderswan"
-		]
-	},
-	"Bandai WonderSwan - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Bandai WonderSwan - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"WonderSwan\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Wanderswan"
-		]
-	},
-	"Benesse Pocket Challenge V2 - ares": {
-		"parserType": "Glob",
-		"configTitle": "Benesse Pocket Challenge V2 - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Pocket Challenge V2\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Pocket Challenge V2"
-		]
-	},
-	"Benesse Pocket Challenge V2 - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Benesse Pocket Challenge V2 - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Pocket Challenge V2\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Pocket Challenge V2"
-		]
-	},
-	"Coleco ColecoVision - ares": {
-		"parserType": "Glob",
-		"configTitle": "Coleco ColecoVision - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"ColecoVision\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.col|.COL|.ri|.RI|.rom|.ROM|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"ColecoVision"
-		]
-	},
-	"Coleco ColecoVision - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Coleco ColecoVision - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"ColecoVision\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.col|.COL|.ri|.RI|.rom|.ROM|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"ColecoVision"
-		]
-	},
-	"Microsoft MSX 2 - ares": {
-		"parserType": "Glob",
-		"configTitle": "Microsoft MSX 2 - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"MSX2\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.cas|.CAS|.dsk|.DSK|.m3u|.M3U|.mx1|.MX1|.mx2|.MX2|.ri|.RI|.rom|.ROM|.sc|.SC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"MSX2"
-		]
-	},
-	"Microsoft MSX 2 - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Microsoft MSX 2 - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"MSX2\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.cas|.CAS|.dsk|.DSK|.m3u|.M3U|.mx1|.MX1|.mx2|.MX2|.ri|.RI|.rom|.ROM|.sc|.SC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"MSX2"
-		]
-	},
-	"Microsoft MSX - ares": {
-		"parserType": "Glob",
-		"configTitle": "Microsoft MSX - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"MSX\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.cas|.CAS|.dsk|.DSK|.m3u|.M3U|.mx1|.MX1|.mx2|.MX2|.ri|.RI|.rom|.ROM|.sc|.SC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"MSX"
-		]
-	},
-	"Microsoft MSX - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Microsoft MSX - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"MSX\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.cas|.CAS|.dsk|.DSK|.m3u|.M3U|.mx1|.MX1|.mx2|.MX2|.ri|.RI|.rom|.ROM|.sc|.SC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"MSX"
-		]
-	},
-	"NEC PC Engine CD/TurboGrafx CD - ares": {
-		"parserType": "Glob",
-		"configTitle": "NEC PC Engine CD/TurboGrafx CD - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"PC Engine CD\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"PCECD"
-		]
-	},
-	"NEC PC Engine CD/TurboGrafx CD - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "NEC PC Engine CD/TurboGrafx CD - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"PC Engine CD\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"PCECD"
-		]
-	},
-	"NEC PC Engine SuperGrafx - ares": {
-		"parserType": "Glob",
-		"configTitle": "NEC PC Engine SuperGrafx - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"SuperGrafx\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"PCESGX"
-		]
-	},
-	"NEC PC Engine SuperGrafx - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "NEC PC Engine SuperGrafx - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"SuperGrafx\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"PCESGX"
-		]
-	},
-	"NEC PC Engine/TurboGrafx 16 - ares": {
-		"parserType": "Glob",
-		"configTitle": "NEC PC Engine/TurboGrafx 16 - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"PC Engine\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"PCE"
-		]
-	},
-	"NEC PC Engine/TurboGrafx 16 - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "NEC PC Engine/TurboGrafx 16 - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"PC Engine\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"PCE"
-		]
-	},
-	"Nintendo 64 - ares": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo 64 - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Nintendo 64\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.n64|.N64|.v64|.V64|.z64|.Z64)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"N64"
-		]
-	},
-	"Nintendo 64 - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo 64 - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Nintendo 64\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.n64|.N64|.v64|.V64|.z64|.Z64)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"N64"
-		]
-	},
-	"Nintendo 64DD - ares": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo 64DD - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Nintendo 64DD\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.n64|.N64|.v64|.V64|.z64|.Z64)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"N64DD"
-		]
-	},
-	"Nintendo 64DD - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo 64DD - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Nintendo 64DD\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.n64|.N64|.v64|.V64|.z64|.Z64)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"N64DD"
-		]
-	},
-	"Nintendo FDS - ares": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo FDS - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Famicom Disk System\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.bz2|.BZ2|.gz|.GZ|.nes|.NES|.fds|.FDS|.unf|.UNF|.xz|.XZ|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"FDS"
-		]
-	},
-	"Nintendo FDS - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo FDS - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Famicom Disk System\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.bz2|.BZ2|.gz|.GZ|.nes|.NES|.fds|.FDS|.unf|.UNF|.xz|.XZ|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"FDS"
-		]
-	},
-	"Nintendo Game Boy Advance - ares": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo Game Boy Advance - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Game Boy Advance\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Game Boy Advance"
-		]
-	},
-	"Nintendo Game Boy Advance - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo Game Boy Advance - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Game Boy Advance\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Game Boy Advance"
-		]
-	},
-	"Nintendo Game Boy Color - ares": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo Game Boy Color - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Game Boy Color\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gbc|.GBC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Game Boy Color"
-		]
-	},
-	"Nintendo Game Boy Color - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo Game Boy Color - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Game Boy Color\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gbc|.GBC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Game Boy Color"
-		]
-	},
-	"Nintendo Game Boy - ares": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo Game Boy - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Game Boy\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Game Boy"
-		]
-	},
-	"Nintendo Game Boy - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo Game Boy - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Game Boy\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Game Boy"
-		]
-	},
-	"Nintendo NES - ares": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo NES - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Famicom\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.bz2|.BZ2|.gz|.GZ|.nes|.NES|.fds|.FDS|.unf|.UNF|.xz|.XZ|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"NES"
-		]
-	},
-	"Nintendo NES - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo NES - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Famicom\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.bz2|.BZ2|.gz|.GZ|.nes|.NES|.fds|.FDS|.unf|.UNF|.xz|.XZ|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"NES"
-		]
-	},
-	"Nintendo SNES - ares": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo SNES - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Super Famicom\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.bs|.BS|.sfc|.SFC|.smc|.SMC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"SNES"
-		]
-	},
-	"Nintendo SNES - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Nintendo SNES - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Super Famicom\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.bs|.BS|.sfc|.SFC|.smc|.SMC|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"SNES"
-		]
-	},
-	"Sega 32X - ares": {
-		"parserType": "Glob",
-		"configTitle": "Sega 32X - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Mega 32X\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.32x|.32X|.bin|.BIN|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"32X"
-		]
-	},
-	"Sega 32X - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Sega 32X - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Mega 32X\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.32x|.32X|.bin|.BIN|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"32X"
-		]
-	},
-	"Sega CD/Mega CD - ares": {
-		"parserType": "Glob",
-		"configTitle": "Sega CD/Mega CD - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Mega CD\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.iso|.ISO|.cue|.CUE|.chd|.CHD|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Sega CD/Mega CD"
-		]
-	},
-	"Sega CD/Mega CD - ares (Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Sega CD/Mega CD - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Mega CD\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.iso|.ISO|.cue|.CUE|.chd|.CHD|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Sega CD/Mega CD"
-		]
-	},
-	"Sega Game Gear - ares": {
-		"parserType": "Glob",
-		"configTitle": "Sega Game Gear - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Game Gear\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.bin|.BIN|.gg|.GG|.rom|.ROM|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Game Gear"
-		]
-	},
-	"Sega Game Gear - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Sega Game Gear - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Game Gear\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.bin|.BIN|.gg|.GG|.rom|.ROM|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Game Gear"
-		]
-	},
-	"Sega Genesis/Mega Drive - ares": {
-		"parserType": "Glob",
-		"configTitle": "Sega Genesis/Mega Drive - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Mega Drive\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP|.bin|.BIN)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Genesis/Mega Drive"
-		]
-	},
-	"Sega Genesis/Mega Drive - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Sega Genesis/Mega Drive - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Mega Drive\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP|.bin|.BIN)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Genesis/Mega Drive"
-		]
-	},
-	"Sega Master System - ares": {
-		"parserType": "Glob",
-		"configTitle": "Sega Master System - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"Master System\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.bin|.BIN|.rom|.ROM|.sms|.SMS|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Master System"
-		]
-	},
-	"Sega Master System - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Sega Master System - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"Master System\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.bin|.BIN|.rom|.ROM|.sms|.SMS|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"Master System"
-		]
-	},
-	"Sega SG-1000 - ares": {
-		"parserType": "Glob",
-		"configTitle": "Sega SG-1000 - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"SG-1000\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.ri|.RI|.rom|.ROM|.sg|.SG|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"SG-1000"
-		]
-	},
-	"Sega SG-1000 - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Sega SG-1000 - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"SG-1000\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.7z|.7Z|.ri|.RI|.rom|.ROM|.sg|.SG|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"SG-1000"
-		]
-	},
-	"Sinclair ZX Spectrum  - ares": {
-		"parserType": "Glob",
-		"configTitle": "Sinclair ZX Spectrum - ares",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "--fullscreen --system \"ZX Spectrum\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.dsk|.DSK|.gz|.GZ|.img|.IMG|.mgt|.MGT|.rzx|.RZX|.scl|.SCL|.sh|.SH|.sna|.SNA|.szx|.SZX|.tap|.TAP|.trd|.TRD|.tzx|.TZX|.udi|.UDI|.z80|.Z80|.7z|.7Z|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "path-to-ares",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"ZX Spectrum"
-		]
-	},
-	"Sinclair ZX Spectrum  - ares(Flatpak)": {
-		"parserType": "Glob",
-		"configTitle": "Sinclair ZX Spectrum - ares(Flatpak)",
-		"executableModifier": "\"${exePath}\"",
-		"romDirectory": "path-to-roms",
-		"steamDirectory": "${steamdirglobal}",
-		"startInDirectory": "",
-		"titleModifier": "${fuzzyTitle}",
-		"executableArgs": "run dev.ares.ares --fullscreen --system \"ZX Spectrum\" \"${filePath}\"",
-		"onlineImageQueries": ["${fuzzyTitle}"],
-		"imagePool": "${fuzzyTitle}",
-		"imageProviders": [
-			"sgdb"
-		],
-		"disabled": false,
-		"userAccounts": {
-			"specifiedAccounts": [
-				"Global"
-			]
-		},
-		"parserInputs": {
-			"glob": "${title}@(.dsk|.DSK|.gz|.GZ|.img|.IMG|.mgt|.MGT|.rzx|.RZX|.scl|.SCL|.sh|.SH|.sna|.SNA|.szx|.SZX|.tap|.TAP|.trd|.TRD|.tzx|.TZX|.udi|.UDI|.z80|.Z80|.7z|.7Z|.zip|.ZIP)"
-		},
-		"titleFromVariable": {
-			"limitToGroups": [],
-			"caseInsensitiveVariables": false,
-			"skipFileIfVariableWasNotFound": false
-		},
-		"fuzzyMatch": {
-			"replaceDiacritics": true,
-			"removeCharacters": true,
-			"removeBrackets": true
-		},
-		"executable": {
-			"path": "/usr/bin/flatpak",
-			"shortcutPassthrough": false,
-			"appendArgsToExecutable": true
-		},
-		"presetVersion": 17,
-		"imageProviderAPIs": {
-			"sgdb": {
-				"nsfw": false,
-				"humor": false,
-				"imageMotionTypes": [
-					"static"
-				],
-				"styles": [],
-				"stylesHero": [],
-				"stylesLogo": [],
-				"stylesIcon": []
-			},
-			"steamCDN": {}
-		},
-		"controllers": {
-			"ps4": null,
-			"ps5": null,
-			"xbox360": null,
-			"xboxone": null,
-			"switch_joycon_left": null,
-			"switch_joycon_right": null,
-			"switch_pro": null,
-			"neptune": null
-		},
-		"defaultImage": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"localImages": {
-			"long": "",
-			"tall": "",
-			"hero": "",
-			"logo": "",
-			"icon": ""
-		},
-		"steamInputEnabled": "1",
-		"drmProtect": false,
-		"steamCategories": [
-			"ZX Spectrum"
-		]
-	}
+  "Atari 2600 - ares": {
+    "parserType": "Glob",
+    "configTitle": "Atari 2600 - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Atari 2600\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.a26|.A26|.bin|.BIN|.rom|.ROM|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["2600"]
+  },
+  "Atari 2600 - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Atari 2600 - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Atari 2600\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.a26|.A26|.bin|.BIN|.rom|.ROM|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["2600"]
+  },
+  "Bandai WonderSwan Color - ares": {
+    "parserType": "Glob",
+    "configTitle": "Bandai WonderSwan Color - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"WonderSwan Color\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Wanderswan Color"]
+  },
+  "Bandai WonderSwan Color - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Bandai WonderSwan Color - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"WonderSwan Color\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Wanderswan Color"]
+  },
+  "Bandai WonderSwan - ares": {
+    "parserType": "Glob",
+    "configTitle": "Bandai WonderSwan - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"WonderSwan\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Wanderswan"]
+  },
+  "Bandai WonderSwan - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Bandai WonderSwan - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"WonderSwan\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Wanderswan"]
+  },
+  "Benesse Pocket Challenge V2 - ares": {
+    "parserType": "Glob",
+    "configTitle": "Benesse Pocket Challenge V2 - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Pocket Challenge V2\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Pocket Challenge V2"]
+  },
+  "Benesse Pocket Challenge V2 - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Benesse Pocket Challenge V2 - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Pocket Challenge V2\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "**/${title}@(.pc2|.PC2|.ws|.WS|.wsc|.WSC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Pocket Challenge V2"]
+  },
+  "Coleco ColecoVision - ares": {
+    "parserType": "Glob",
+    "configTitle": "Coleco ColecoVision - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"ColecoVision\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.col|.COL|.ri|.RI|.rom|.ROM|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["ColecoVision"]
+  },
+  "Coleco ColecoVision - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Coleco ColecoVision - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"ColecoVision\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.col|.COL|.ri|.RI|.rom|.ROM|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["ColecoVision"]
+  },
+  "Microsoft MSX 2 - ares": {
+    "parserType": "Glob",
+    "configTitle": "Microsoft MSX 2 - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"MSX2\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.cas|.CAS|.dsk|.DSK|.m3u|.M3U|.mx1|.MX1|.mx2|.MX2|.ri|.RI|.rom|.ROM|.sc|.SC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["MSX2"]
+  },
+  "Microsoft MSX 2 - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Microsoft MSX 2 - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"MSX2\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.cas|.CAS|.dsk|.DSK|.m3u|.M3U|.mx1|.MX1|.mx2|.MX2|.ri|.RI|.rom|.ROM|.sc|.SC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["MSX2"]
+  },
+  "Microsoft MSX - ares": {
+    "parserType": "Glob",
+    "configTitle": "Microsoft MSX - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"MSX\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.cas|.CAS|.dsk|.DSK|.m3u|.M3U|.mx1|.MX1|.mx2|.MX2|.ri|.RI|.rom|.ROM|.sc|.SC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["MSX"]
+  },
+  "Microsoft MSX - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Microsoft MSX - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"MSX\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.cas|.CAS|.dsk|.DSK|.m3u|.M3U|.mx1|.MX1|.mx2|.MX2|.ri|.RI|.rom|.ROM|.sc|.SC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["MSX"]
+  },
+  "NEC PC Engine CD/TurboGrafx CD - ares": {
+    "parserType": "Glob",
+    "configTitle": "NEC PC Engine CD/TurboGrafx CD - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"PC Engine CD\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["PCECD"]
+  },
+  "NEC PC Engine CD/TurboGrafx CD - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "NEC PC Engine CD/TurboGrafx CD - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"PC Engine CD\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["PCECD"]
+  },
+  "NEC PC Engine SuperGrafx - ares": {
+    "parserType": "Glob",
+    "configTitle": "NEC PC Engine SuperGrafx - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"SuperGrafx\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["PCESGX"]
+  },
+  "NEC PC Engine SuperGrafx - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "NEC PC Engine SuperGrafx - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"SuperGrafx\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["PCESGX"]
+  },
+  "NEC PC Engine/TurboGrafx 16 - ares": {
+    "parserType": "Glob",
+    "configTitle": "NEC PC Engine/TurboGrafx 16 - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"PC Engine\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["PCE"]
+  },
+  "NEC PC Engine/TurboGrafx 16 - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "NEC PC Engine/TurboGrafx 16 - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"PC Engine\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.ccd|.CCD|.chd|.CHD|.cue|.CUE|.iso|.ISO|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["PCE"]
+  },
+  "Nintendo 64 - ares": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo 64 - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Nintendo 64\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.n64|.N64|.v64|.V64|.z64|.Z64)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["N64"]
+  },
+  "Nintendo 64 - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo 64 - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Nintendo 64\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.n64|.N64|.v64|.V64|.z64|.Z64)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["N64"]
+  },
+  "Nintendo 64DD - ares": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo 64DD - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Nintendo 64DD\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.n64|.N64|.v64|.V64|.z64|.Z64)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["N64DD"]
+  },
+  "Nintendo 64DD - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo 64DD - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Nintendo 64DD\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.n64|.N64|.v64|.V64|.z64|.Z64)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["N64DD"]
+  },
+  "Nintendo FDS - ares": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo FDS - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Famicom Disk System\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.bz2|.BZ2|.gz|.GZ|.nes|.NES|.fds|.FDS|.unf|.UNF|.xz|.XZ|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["FDS"]
+  },
+  "Nintendo FDS - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo FDS - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Famicom Disk System\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.bz2|.BZ2|.gz|.GZ|.nes|.NES|.fds|.FDS|.unf|.UNF|.xz|.XZ|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["FDS"]
+  },
+  "Nintendo Game Boy Advance - ares": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo Game Boy Advance - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Game Boy Advance\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Game Boy Advance"]
+  },
+  "Nintendo Game Boy Advance - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo Game Boy Advance - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Game Boy Advance\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.gba|.GBA|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Game Boy Advance"]
+  },
+  "Nintendo Game Boy Color - ares": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo Game Boy Color - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Game Boy Color\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.gbc|.GBC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Game Boy Color"]
+  },
+  "Nintendo Game Boy Color - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo Game Boy Color - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Game Boy Color\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.gbc|.GBC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Game Boy Color"]
+  },
+  "Nintendo Game Boy - ares": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo Game Boy - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Game Boy\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Game Boy"]
+  },
+  "Nintendo Game Boy - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo Game Boy - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Game Boy\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.gb|.GB|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Game Boy"]
+  },
+  "Nintendo NES - ares": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo NES - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Famicom\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.bz2|.BZ2|.gz|.GZ|.nes|.NES|.fds|.FDS|.unf|.UNF|.xz|.XZ|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["NES"]
+  },
+  "Nintendo NES - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo NES - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Famicom\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.bz2|.BZ2|.gz|.GZ|.nes|.NES|.fds|.FDS|.unf|.UNF|.xz|.XZ|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["NES"]
+  },
+  "Nintendo SNES - ares": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo SNES - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Super Famicom\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.bs|.BS|.sfc|.SFC|.smc|.SMC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["SNES"]
+  },
+  "Nintendo SNES - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Nintendo SNES - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Super Famicom\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.bs|.BS|.sfc|.SFC|.smc|.SMC|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["SNES"]
+  },
+  "Sega 32X - ares": {
+    "parserType": "Glob",
+    "configTitle": "Sega 32X - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Mega 32X\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.32x|.32X|.bin|.BIN|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["32X"]
+  },
+  "Sega 32X - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Sega 32X - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Mega 32X\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.32x|.32X|.bin|.BIN|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["32X"]
+  },
+  "Sega CD/Mega CD - ares": {
+    "parserType": "Glob",
+    "configTitle": "Sega CD/Mega CD - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Mega CD\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.iso|.ISO|.cue|.CUE|.chd|.CHD|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Sega CD/Mega CD"]
+  },
+  "Sega CD/Mega CD - ares (Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Sega CD/Mega CD - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Mega CD\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.iso|.ISO|.cue|.CUE|.chd|.CHD|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Sega CD/Mega CD"]
+  },
+  "Sega Game Gear - ares": {
+    "parserType": "Glob",
+    "configTitle": "Sega Game Gear - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Game Gear\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.bin|.BIN|.gg|.GG|.rom|.ROM|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Game Gear"]
+  },
+  "Sega Game Gear - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Sega Game Gear - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Game Gear\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.bin|.BIN|.gg|.GG|.rom|.ROM|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Game Gear"]
+  },
+  "Sega Genesis/Mega Drive - ares": {
+    "parserType": "Glob",
+    "configTitle": "Sega Genesis/Mega Drive - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Mega Drive\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP|.bin|.BIN)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Genesis/Mega Drive"]
+  },
+  "Sega Genesis/Mega Drive - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Sega Genesis/Mega Drive - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Mega Drive\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.gen|.GEN|.md|.MD|.smd|.SMD|.zip|.ZIP|.bin|.BIN)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Genesis/Mega Drive"]
+  },
+  "Sega Master System - ares": {
+    "parserType": "Glob",
+    "configTitle": "Sega Master System - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"Master System\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.bin|.BIN|.rom|.ROM|.sms|.SMS|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Master System"]
+  },
+  "Sega Master System - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Sega Master System - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"Master System\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.bin|.BIN|.rom|.ROM|.sms|.SMS|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["Master System"]
+  },
+  "Sega SG-1000 - ares": {
+    "parserType": "Glob",
+    "configTitle": "Sega SG-1000 - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"SG-1000\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.ri|.RI|.rom|.ROM|.sg|.SG|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["SG-1000"]
+  },
+  "Sega SG-1000 - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Sega SG-1000 - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"SG-1000\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.7z|.7Z|.ri|.RI|.rom|.ROM|.sg|.SG|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["SG-1000"]
+  },
+  "Sinclair ZX Spectrum  - ares": {
+    "parserType": "Glob",
+    "configTitle": "Sinclair ZX Spectrum - ares",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "--fullscreen --system \"ZX Spectrum\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.dsk|.DSK|.gz|.GZ|.img|.IMG|.mgt|.MGT|.rzx|.RZX|.scl|.SCL|.sh|.SH|.sna|.SNA|.szx|.SZX|.tap|.TAP|.trd|.TRD|.tzx|.TZX|.udi|.UDI|.z80|.Z80|.7z|.7Z|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "path-to-ares",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["ZX Spectrum"]
+  },
+  "Sinclair ZX Spectrum  - ares(Flatpak)": {
+    "parserType": "Glob",
+    "configTitle": "Sinclair ZX Spectrum - ares(Flatpak)",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "path-to-roms",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "run dev.ares.ares --fullscreen --system \"ZX Spectrum\" \"${filePath}\"",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}@(.dsk|.DSK|.gz|.GZ|.img|.IMG|.mgt|.MGT|.rzx|.RZX|.scl|.SCL|.sh|.SH|.sna|.SNA|.szx|.SZX|.tap|.TAP|.trd|.TRD|.tzx|.TZX|.udi|.UDI|.z80|.Z80|.7z|.7Z|.zip|.ZIP)"
+    },
+    "titleFromVariable": {
+      "limitToGroups": [],
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "/usr/bin/flatpak",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "presetVersion": 17,
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": false,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["ZX Spectrum"]
+  }
 }

--- a/src/lang/en-US/langStrings.json
+++ b/src/lang/en-US/langStrings.json
@@ -39,7 +39,7 @@
         "readingVDF_Files": "Reading VDF files.",
         "mergingVDF_entries": "Merging VDF entries.",
         "removingVDF_entries": "Removing VDF entries and image files.",
-        "savingCategories": "Saving category information to localconfig.vdf.",
+        "savingCategories": "Saving category information to Steam (trying cloud storage, then localconfig.vdf, then leveldb).",
         "savingControllers": "Saving controller information.",
         "removingFromCategories": "Removing all added category information",
         "writingVDF_entries__i": "Writing VDF files. Doing artwork in batches of ${batchSize}.",

--- a/src/lib/category-manager.ts
+++ b/src/lib/category-manager.ts
@@ -4,10 +4,13 @@ import {
   VDF_ExtraneousItemsData,
   VDF_AddedCategoriesData,
 } from "../models";
+import * as genericParser from "@node-steam/vdf";
 import * as steam from "./helpers/steam";
 import { superTypes, ArtworkOnlyType } from "./parsers/available-parsers";
+import * as SteamCategories from "steam-categories";
 import * as path from "path";
 import * as fs from "fs-extra";
+import * as os from "os";
 import * as _ from "lodash";
 import { Acceptable_Error } from "./acceptable-error";
 
@@ -39,7 +42,26 @@ export class CategoryManager {
     ) => Promise<any>,
     data?: any,
   ) {
-    // Setup Task - Modern Steam stores collections in localconfig.vdf
+    // Setup Task
+    let levelDBPath: string;
+    if (os.type() == "Windows_NT") {
+      levelDBPath = path.join(
+        process.env.localappdata,
+        "Steam",
+        "htmlcache",
+        "Local Storage",
+        "leveldb",
+      );
+    } else {
+      levelDBPath = path.join(
+        steamDirectory,
+        "config",
+        "htmlcache",
+        "Local Storage",
+        "leveldb",
+      );
+    }
+    const cats = new SteamCategories(levelDBPath, userId);
     const localConfigPath = path.join(
       steamDirectory,
       "userdata",
@@ -47,228 +69,178 @@ export class CategoryManager {
       "config",
       "localconfig.vdf",
     );
-
-    if (!fs.existsSync(localConfigPath)) {
-      throw new Error(`localconfig.vdf not found at: ${localConfigPath}`);
-    }
-
-    // Check if Steam is running - we cannot safely modify the file if it is
-    const { execSync } = require('child_process');
-    try {
-      const processes = execSync('ps aux', { encoding: 'utf-8' });
-      const steamProcesses = processes.split('\n').filter((line: string) => {
-        const lower = line.toLowerCase();
-        // Must contain 'steam'
-        if (!lower.includes('steam')) return false;
-
-        // Exclude: grep, SRM itself, SteamOS system services, other tools
-        const excludePatterns = [
-          'grep',
-          'avahi-daemon',
-          'steam-rom-manager',
-          'steam rom manager',
-          'steamos-',           // SteamOS system services (steamos-manager, steamos_log_submitter, etc.)
-          'steamgriddb',        // Decky plugin
-          'sddm',               // Display manager
-          '/usr/lib/steamos',   // SteamOS system paths
-          '/usr/bin/python',    // Python scripts (steamos_log_submitter)
-        ];
-
-        return !excludePatterns.some(pattern => lower.includes(pattern));
-      });
-
-      if (steamProcesses.length > 0) {
-        throw new Error(
-          'Steam is currently running. Please close Steam completely before using Steam ROM Manager to modify collections.\n\n' +
-          'To close Steam:\n' +
-          '- Linux: Run "pkill -9 steam" in terminal\n' +
-          '- Windows: Close Steam from system tray\n' +
-          '- Mac: Quit Steam from menu bar\n\n' +
-          'Running processes found:\n' + steamProcesses.slice(0, 5).join('\n')
-        );
-      }
-    } catch (error) {
-      if (error.message.includes('Steam is currently running')) {
-        throw error;
-      }
-      // If ps command fails (e.g., on Windows), log but continue
-      console.log('Could not check for Steam processes:', error.message);
-    }
-
-    // Read existing collections from CLOUD STORAGE (the authoritative source)
-    // NOT from localconfig.vdf (which is just Steam's local cache)
+    let localConfig = genericParser.parse(
+      fs.readFileSync(localConfigPath, "utf-8"),
+    );
     let collections: any = {};
+    let levelCollections: any = {};
+    const lcs = await cats.read();
+    if (localConfig.UserLocalConfigStore.WebStorage["user-collections"]) {
+      collections = JSON.parse(
+        localConfig.UserLocalConfigStore.WebStorage["user-collections"].replace(
+          /\\"/g,
+          '"',
+        ),
+      );
+    }
+    if (lcs && Object.keys(lcs).length) {
+      try {
+        const topKey = Object.keys(lcs)[0];
+        levelCollections = Object.fromEntries(
+          Object.keys(lcs[topKey])
+            .filter(
+              (s) =>
+                s.startsWith("user-collections") && !lcs[topKey][s].is_deleted,
+            )
+            .map((s) => {
+              return [[s.split(".")[1]], _.cloneDeep(lcs[topKey][s].value)];
+            }),
+        );
+      } catch (e) {}
+    }
 
+    // NEW: Also read from cloud storage
     const cloudStorageDir = path.join(
       steamDirectory,
       "userdata",
       userId,
       "config",
-      "cloudstorage"
+      "cloudstorage",
     );
-    const namespacesPath = path.join(cloudStorageDir, "cloud-storage-namespaces.json");
+    const namespacesPath = path.join(
+      cloudStorageDir,
+      "cloud-storage-namespaces.json",
+    );
 
-    let activeNamespace = 1; // Default to namespace 1
+    let activeNamespace = 1;
     if (fs.existsSync(namespacesPath)) {
       try {
-        const namespaces = JSON.parse(fs.readFileSync(namespacesPath, 'utf-8'));
-        // Format: [[1,"798"],[3,"0"]] - find the one with highest version
-        const sorted = namespaces.sort((a: any, b: any) => parseInt(b[1]) - parseInt(a[1]));
+        const namespaces = JSON.parse(fs.readFileSync(namespacesPath, "utf-8"));
+        const sorted = namespaces.sort(
+          (a: any, b: any) => parseInt(b[1]) - parseInt(a[1]),
+        );
         if (sorted.length > 0 && sorted[0][1] !== "0") {
           activeNamespace = sorted[0][0];
         }
       } catch (e) {
-        console.warn(`Could not parse namespaces file, using default namespace 1:`, e.message);
+        console.warn(
+          `Could not parse namespaces file, using default namespace 1:`,
+          e.message,
+        );
       }
     }
 
     const cloudStoragePath = path.join(
       cloudStorageDir,
-      `cloud-storage-namespace-${activeNamespace}.json`
+      `cloud-storage-namespace-${activeNamespace}.json`,
     );
 
+    // Merge cloud storage into collections
     if (fs.existsSync(cloudStoragePath)) {
       try {
-        const cloudData = JSON.parse(fs.readFileSync(cloudStoragePath, 'utf-8'));
-        // Extract collections from cloud storage
+        const cloudData = JSON.parse(
+          fs.readFileSync(cloudStoragePath, "utf-8"),
+        );
         cloudData.forEach((item: any) => {
-          if (item && item[0] && item[0].startsWith('user-collections.')) {
-            const collectionId = item[0].replace('user-collections.', '');
+          if (item && item[0] && item[0].startsWith("user-collections.")) {
+            const collectionId = item[0].replace("user-collections.", "");
             if (!item[1].is_deleted && item[1].value) {
               try {
-                collections[collectionId] = JSON.parse(item[1].value);
+                const cloudCollection = JSON.parse(item[1].value);
+                // Merge cloud data with local collections (cloud takes precedence)
+                collections[collectionId] = cloudCollection;
               } catch (e) {
-                console.warn(`Failed to parse collection ${collectionId}:`, e.message);
+                console.warn(
+                  `Failed to parse collection ${collectionId}:`,
+                  e.message,
+                );
               }
             }
           }
         });
       } catch (e) {
-        console.warn(`Failed to read cloud storage, starting with empty collections:`, e.message);
+        console.warn(`Failed to read cloud storage:`, e.message);
       }
     }
 
     try {
-      // Do Task - LevelDB no longer used, passing empty objects for compatibility
-      collections = await task(collections, {}, { remove: () => {}, close: async () => {} }, data);
-
-      // Write collections to cloud storage (Steam will sync localconfig.vdf automatically)
+      // Do Task
+      collections = await task(collections, levelCollections, cats, data);
+      // Cleanup if task is not readonly
       if (!data || !data.readonly) {
-        try {
-          if (fs.existsSync(cloudStoragePath)) {
-            try {
-              const cloudData = JSON.parse(fs.readFileSync(cloudStoragePath, 'utf-8'));
-              const timestamp = Math.floor(Date.now() / 1000);
+        // Write to the LevelDB
+        await cats.save();
 
-              // MERGE LOGIC: Only modify SRM collections, preserve all other data
+        // NEW: Write to cloud storage
+        if (fs.existsSync(cloudStoragePath)) {
+          try {
+            const cloudData = JSON.parse(
+              fs.readFileSync(cloudStoragePath, "utf-8"),
+            );
+            const timestamp = Math.floor(Date.now() / 1000);
 
-              // Step 1: Build map of existing SRM collections in cloud storage
-              const existingSRMCollections = new Map<string, number>();
-              cloudData.forEach((item: any, index: number) => {
-                if (item && item[0] && item[0].startsWith('user-collections.srm-')) {
-                  existingSRMCollections.set(item[0], index);
-                }
-              });
+            const existingSRMCollections = new Map<string, number>();
+            cloudData.forEach((item: any, index: number) => {
+              if (
+                item &&
+                item[0] &&
+                item[0].startsWith("user-collections.srm-")
+              ) {
+                existingSRMCollections.set(item[0], index);
+              }
+            });
 
-              // Step 2: Update or add SRM collections from our current set
-              for (const [collectionId, collectionData] of Object.entries(collections)) {
-                const key = `user-collections.${collectionId}`;
-                const existingIndex = existingSRMCollections.get(key);
+            for (const [collectionId, collectionData] of Object.entries(
+              collections,
+            )) {
+              const key = `user-collections.${collectionId}`;
+              const existingIndex = existingSRMCollections.get(key);
 
-                const cloudEntry = [key, {
+              const cloudEntry = [
+                key,
+                {
                   key: key,
                   timestamp: timestamp,
                   value: JSON.stringify(collectionData),
                   version: String(timestamp),
                   conflictResolutionMethod: "custom",
-                  strMethodId: "union-collections"
-                }];
+                  strMethodId: "union-collections",
+                },
+              ];
 
-                if (existingIndex !== undefined) {
-                  // Update existing SRM collection
-                  cloudData[existingIndex] = cloudEntry;
-                  existingSRMCollections.delete(key); // Mark as processed
-                } else {
-                  // Add new SRM collection
-                  cloudData.push(cloudEntry);
-                }
-              }
-
-              // Step 3: Mark remaining SRM collections (not in our set) as deleted
-              // These are SRM collections that existed before but are no longer managed
-              for (const [key, index] of existingSRMCollections.entries()) {
-                if (cloudData[index] && !cloudData[index][1].is_deleted) {
-                  cloudData[index][1].is_deleted = true;
-                  cloudData[index][1].timestamp = timestamp;
-                }
-              }
-
-              // Step 4: Write the merged data
-              fs.writeFileSync(cloudStoragePath, JSON.stringify(cloudData), { encoding: 'utf-8' });
-            } catch (cloudError) {
-              console.warn('Failed to update cloud storage:', cloudError.message);
-              // Continue to try VDF as fallback
-            }
-          }
-
-          // Also write to localconfig.vdf as fallback for older Steam versions (pre-Sept 2025)
-          // Modern Steam (Sept 2025+) reads from cloud storage and syncs VDF automatically
-          // Older Steam (2024-Sept 2025) reads from localconfig.vdf directly
-          try {
-            const localConfigPath = path.join(steamDirectory, "userdata", userId, "config", "localconfig.vdf");
-
-            if (fs.existsSync(localConfigPath)) {
-
-              const localConfigRaw = fs.readFileSync(localConfigPath, "utf-8");
-              const collectionsJson = JSON.stringify(collections);
-              const escapedCollections = collectionsJson.replace(/"/g, '\\"');
-
-              // Use regex to preserve key ordering (avoid @node-steam/vdf stringify which reorders keys)
-              const userCollectionsMatch = localConfigRaw.match(/"user-collections"\s+"[^"]+"/);
-              let newVdfContent: string;
-
-              if (userCollectionsMatch) {
-                newVdfContent = localConfigRaw.replace(
-                  /"user-collections"\s+"[^"]+"/,
-                  `"user-collections"\t\t"${escapedCollections}"`
-                );
+              if (existingIndex !== undefined) {
+                cloudData[existingIndex] = cloudEntry;
+                existingSRMCollections.delete(key);
               } else {
-                // Add new user-collections field
-                const webStorageEndMatch = localConfigRaw.match(/(\s*)"WebStorage"\s*\{[\s\S]*?\n(\s*)\}/);
-                if (webStorageEndMatch) {
-                  const indent = webStorageEndMatch[2];
-                  const insertPoint = webStorageEndMatch.index + webStorageEndMatch[0].length - (indent.length + 1);
-                  newVdfContent = localConfigRaw.slice(0, insertPoint) +
-                    `${indent}\t"user-collections"\t\t"${escapedCollections}"\n` +
-                    localConfigRaw.slice(insertPoint);
-                } else {
-                  throw new Error('Could not find WebStorage section in localconfig.vdf');
-                }
+                cloudData.push(cloudEntry);
               }
-
-              fs.writeFileSync(localConfigPath, newVdfContent, { encoding: 'utf-8' });
             }
-          } catch (vdfError) {
-            console.warn(`Failed to write localconfig.vdf fallback:`, vdfError.message);
-            // Non-fatal - cloud storage is the primary method
-          }
 
-        } catch (writeError) {
-          console.error(`Failed to write collections:`, writeError.message);
-          throw new Error(`Could not save collections: ${writeError.message}`);
+            for (const [key, index] of existingSRMCollections.entries()) {
+              if (cloudData[index] && !cloudData[index][1].is_deleted) {
+                cloudData[index][1].is_deleted = true;
+                cloudData[index][1].timestamp = timestamp;
+              }
+            }
+
+            fs.writeFileSync(cloudStoragePath, JSON.stringify(cloudData), {
+              encoding: "utf-8",
+            });
+          } catch (cloudError) {
+            console.warn("Failed to update cloud storage:", cloudError.message);
+          }
         }
+
+        // Write Local Category Information
+        localConfig.UserLocalConfigStore.WebStorage["user-collections"] =
+          JSON.stringify(collections).replace(/"/g, '\\"');
+        fs.writeFileSync(localConfigPath, genericParser.stringify(localConfig));
       }
     } catch (e) {
       throw e;
+    } finally {
+      await cats.close();
     }
-    // LevelDB is no longer used - no need to close
-    // finally {
-    //   try {
-    //     await cats.close();
-    //   } catch (closeError) {
-    //     // Ignore close errors for mock object
-    //   }
-    // }
   }
   // toRemove is assumed to be a subset of the keys of addedCategories.
   removeShortsFromCats(
@@ -297,34 +269,24 @@ export class CategoryManager {
       if (catKey.startsWith("srm") && nonSRMAdded.length == 0) {
         delete collections[catKey];
         // only remove the level collection if newAdded is empty *and* the level collection itself is empty
-        // LevelDB is no longer used for collections in modern Steam
-        // if (
-        //   levelCollections[catKey] &&
-        //   levelCollections[catKey].added.length == 0
-        // ) {
-        //   try {
-        //     cats.remove(catKey);
-        //   } catch (e) {
-        //     console.warn('Could not remove from LevelDB:', catKey, e.message);
-        //   }
-        // }
+        if (
+          levelCollections[catKey] &&
+          levelCollections[catKey].added.length == 0
+        ) {
+          cats.remove(catKey);
+        }
       }
     }
-    // LevelDB is no longer used for collections in modern Steam
-    // //Get the ones in levelCollection that we missed
-    // for (const catKey of levelKeys) {
-    //   if (
-    //     catKey.startsWith("srm") &&
-    //     !collections[catKey] &&
-    //     levelCollections[catKey].added.length == 0
-    //   ) {
-    //     try {
-    //       cats.remove(catKey);
-    //     } catch (e) {
-    //       console.warn('Could not remove from LevelDB:', catKey, e.message);
-    //     }
-    //   }
-    // }
+    //Get the ones in levelCollection that we missed
+    for (const catKey of levelKeys) {
+      if (
+        catKey.startsWith("srm") &&
+        !collections[catKey] &&
+        levelCollections[catKey].added.length == 0
+      ) {
+        cats.remove(catKey);
+      }
+    }
   }
 
   removeAllCategoriesAndWrite(
@@ -432,66 +394,38 @@ export class CategoryManager {
             const appIdNew = parseInt(steam.shortenAppId(appId), 10);
             // Loop "steamCategories" for app
             app.steamCategories.forEach((catName: string) => {
-              if (!catName || catName.trim() === '') {
-                console.warn('Skipping empty category name');
-                return;
-              }
-
-              // Create a consistent, safe collection key
-              const safeCatName = catName.trim();
-              let catKey: string;
-
-              // Check if collection already exists (case-insensitive search)
-              const existingKey = Object.keys(collections).find(key => {
-                if (collections[key] && collections[key].name) {
-                  return collections[key].name.toUpperCase() === safeCatName.toUpperCase();
-                }
-                return false;
-              });
-
-              if (existingKey) {
-                catKey = existingKey;
+              // check the levelDB collections to see if a category already exists
+              const lcKeys = Object.keys(levelCollections).filter(
+                (lckey: string) =>
+                  levelCollections[lckey].name.toUpperCase() ===
+                  catName.toUpperCase(),
+              );
+              let catKey;
+              if (lcKeys.length) {
+                catKey = levelCollections[lcKeys[0]].id;
               } else {
-                // Generate a new collection key using base64 encoding for safety
-                const base64Name = Buffer.from(safeCatName, 'utf8')
-                  .toString('base64')
-                  .replace(/[+/=]/g, (match) => {
-                    return { '+': '-', '/': '_', '=': '' }[match] || match;
-                  });
-                catKey = `srm-${base64Name}`;
+                catKey = `srm-${Buffer.from(catName).toString("base64")}`;
               }
-
-              // Ensure collection exists in localconfig.vdf with proper structure
+              // Create level collection if it doesn't exist or is deleted
+              if (((x) => !x || x.is_deleted)(cats.get(catKey))) {
+                cats.add(catKey, {
+                  name: catName,
+                  added: [],
+                });
+              }
+              // Create entries in localconfig.vdf
               if (!collections[catKey]) {
                 collections[catKey] = {
                   id: catKey,
-                  name: safeCatName,
                   added: [],
-                  removed: []
+                  removed: [],
                 };
               }
-
-              // Ensure the collection has the correct name (in case it was updated)
-              collections[catKey].name = safeCatName;
-
-              // Ensure arrays exist
-              if (!collections[catKey].added) {
-                collections[catKey].added = [];
-              }
-              if (!collections[catKey].removed) {
-                collections[catKey].removed = [];
-              }
-
-              // Add app to collection if not already present
+              // Add appids to localconfig.vdf
               if (!collections[catKey].added.includes(appIdNew)) {
                 collections[catKey].added.push(appIdNew);
               }
-
-              // Remove from removed list if present
-              const removedIndex = collections[catKey].removed.indexOf(appIdNew);
-              if (removedIndex > -1) {
-                collections[catKey].removed.splice(removedIndex, 1);
-              }
+              // Add appids to leveldb
             });
           }
           resolve(collections);

--- a/src/lib/file-parser.ts
+++ b/src/lib/file-parser.ts
@@ -600,12 +600,7 @@ export class FileParser {
             newFile.imagePool = fuzzyTitle;
           }
 
-          // Use Steam Category field if provided, otherwise fall back to parser config title
-          // Filter out empty strings and trim whitespace
-          const categories = config.steamCategories
-            .map(cat => cat.trim())
-            .filter(cat => cat.length > 0);
-          newFile.steamCategories = categories.length > 0 ? categories : [config.configTitle];
+          newFile.steamCategories = config.steamCategories;
 
           parsedConfig.files.push(newFile);
         }

--- a/src/lib/parsers/manual.parser.ts
+++ b/src/lib/parsers/manual.parser.ts
@@ -47,8 +47,7 @@ export class ManualParser implements GenericParser {
                   filePath: jsonObjs[j].target,
                   startInDirectory: jsonObjs[j].startIn,
                   launchOptions: jsonObjs[j].launchOptions,
-                  appendArgsToExecutable:
-                    !!jsonObjs[j].appendArgsToExecutable,
+                  appendArgsToExecutable: !!jsonObjs[j].appendArgsToExecutable,
                 });
               }
             } catch (err) {

--- a/src/lib/string-interpolation.ts
+++ b/src/lib/string-interpolation.ts
@@ -13,7 +13,8 @@ String.prototype.interpolate = function (params: any) {
   return new Function(...names, `return \`${this}\`;`)(...vals);
 };
 
-
-String.prototype.startCase = function() {
-  return this.split(/\s/g).map((w: string)=>_.capitalize(w)).join(" ");
-} 
+String.prototype.startCase = function () {
+  return this.split(/\s/g)
+    .map((w: string) => _.capitalize(w))
+    .join(" ");
+};

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -283,8 +283,16 @@ app.on("ready", () => {
         app.quit();
       },
     );
-    ipcMain.on("all_done", (event: IpcMainEvent) => {
+    ipcMain.on("all_done", async (event: IpcMainEvent) => {
       console.log("\nAll Done");
+
+      // Restart Steam if it was killed and not already restarted
+      const { wasSteamKilled, startSteam } = await import("../lib/helpers/steam/stop-start-steam");
+      if (wasSteamKilled()) {
+        console.log("Restarting Steam before app exit...");
+        await startSteam();
+      }
+
       app.quit();
     });
     ipcMain.on("log", (event: IpcMainEvent, loggable: any) => {
@@ -319,7 +327,14 @@ app.on("ready", () => {
   }
 });
 
-app.on("window-all-closed", () => {
+app.on("window-all-closed", async () => {
+  // Restart Steam if it was killed and not already restarted
+  const { wasSteamKilled, startSteam } = await import("../lib/helpers/steam/stop-start-steam");
+  if (wasSteamKilled()) {
+    console.log("Restarting Steam before app exit...");
+    await startSteam();
+  }
+
   if (process.platform !== "darwin") {
     app.quit();
   }

--- a/src/renderer/app.module.ts
+++ b/src/renderer/app.module.ts
@@ -35,7 +35,7 @@ function ngObjectsToArray<T>(importObject: T) {
     FormsModule,
     ReactiveFormsModule,
     ColorPickerModule,
-    DragAndDropModule
+    DragAndDropModule,
   ],
   declarations: [
     Components.AboutComponent,

--- a/src/renderer/components/logger.component.ts
+++ b/src/renderer/components/logger.component.ts
@@ -6,7 +6,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Renderer2,
-  RendererStyleFlags2
+  RendererStyleFlags2,
 } from "@angular/core";
 import { FormGroup, FormBuilder } from "@angular/forms";
 import { LoggerService, SettingsService } from "../services";
@@ -36,7 +36,7 @@ export class LoggerComponent {
   description: string = "";
   discordHandle: string = "";
   bugForm: FormGroup;
-  showReporter:boolean = false;
+  showReporter: boolean = false;
 
   @ViewChild("messageWindow") private messageWindow: ElementRef;
 
@@ -46,7 +46,7 @@ export class LoggerComponent {
     private formBuilder: FormBuilder,
     private renderer: Renderer2,
     private elementRef: ElementRef,
-    private settingsService: SettingsService
+    private settingsService: SettingsService,
   ) {
     this.settings = this.loggerService.getLogSettings();
     this.appSettings = this.settingsService.getSettings();
@@ -139,7 +139,7 @@ export class LoggerComponent {
   clearLog() {
     this.loggerService.clearLog();
   }
-  
+
   closeOptions() {
     this.showOptions = false;
     this.renderer.setStyle(
@@ -159,7 +159,7 @@ export class LoggerComponent {
       RendererStyleFlags2.DashCase,
     );
   }
-  
+
   toggleOptions() {
     if (this.showOptions) {
       this.closeOptions();

--- a/src/renderer/components/nav-parsers.component.ts
+++ b/src/renderer/components/nav-parsers.component.ts
@@ -56,8 +56,8 @@ export class NavParsersComponent implements OnDestroy {
       this.parsersService
         .getUserConfigurations()
         .subscribe((userConfigurations) => {
-          if(this.appSettings.theme == "EmuDeck") {
-            this.initializeImageMap(userConfigurations)
+          if (this.appSettings.theme == "EmuDeck") {
+            this.initializeImageMap(userConfigurations);
           }
           this.userConfigurations = userConfigurations;
 
@@ -69,10 +69,17 @@ export class NavParsersComponent implements OnDestroy {
           this.navForm = this.formBuilder.group({
             selectAll: someOn,
             parserStatuses: this.formBuilder.group(
-              Object.fromEntries(this.userConfigurations.map((config: {saved: UserConfiguration, current: UserConfiguration}) => {
-                return [config.saved.parserId, !config.saved.disabled]
-              }))
-            )
+              Object.fromEntries(
+                this.userConfigurations.map(
+                  (config: {
+                    saved: UserConfiguration;
+                    current: UserConfiguration;
+                  }) => {
+                    return [config.saved.parserId, !config.saved.disabled];
+                  },
+                ),
+              ),
+            ),
           });
           this.navForm
             .get("selectAll")
@@ -87,11 +94,11 @@ export class NavParsersComponent implements OnDestroy {
               }
             });
           const parserControls = this.getParserControls();
-          for(let userConfiguration of this.userConfigurations) {
+          for (let userConfiguration of this.userConfigurations) {
             let parserId = userConfiguration.saved.parserId;
-            parserControls[parserId].valueChanges.subscribe((val: boolean)=>{
+            parserControls[parserId].valueChanges.subscribe((val: boolean) => {
               this.parsersService.changeEnabledStatus(parserId, val);
-            })
+            });
           }
 
           this.changeRef.detectChanges();
@@ -104,13 +111,13 @@ export class NavParsersComponent implements OnDestroy {
         this.changeRef.detectChanges();
       }),
     );
-    if(this.appSettings.theme == 'Deck') {
+    if (this.appSettings.theme == "Deck") {
       this.subscriptions.add(
-        this.navClick.subscribe(()=>{
-          this.currentId="";
+        this.navClick.subscribe(() => {
+          this.currentId = "";
           this.changeRef.detectChanges();
-        })
-      )
+        }),
+      );
     }
 
     this.languageService.observeChanges().subscribe((lang) => {
@@ -138,55 +145,61 @@ export class NavParsersComponent implements OnDestroy {
   }
 
   getRouteIndex(route: string) {
-    return parseInt(route.split("/")[2])
+    return parseInt(route.split("/")[2]);
   }
 
   dragStart(event: Event) {
     this.dragStartIndex = this.getRouteIndex(this.router.url);
   }
 
-  handleDrop(fromIndex: number, toIndex:number) {
+  handleDrop(fromIndex: number, toIndex: number) {
     this.parsersService.injectIndex(fromIndex, toIndex);
-    if(fromIndex < this.dragStartIndex && this.dragStartIndex <= toIndex) {
-      this.router.navigate(["/parsers", this.dragStartIndex - 1])
-    } else if(toIndex <= this.dragStartIndex && this.dragStartIndex < fromIndex) {
-      this.router.navigate(["/parsers", this.dragStartIndex + 1])
-    } else if(this.dragStartIndex==fromIndex) {
-      this.router.navigate(["/parsers", toIndex])
+    if (fromIndex < this.dragStartIndex && this.dragStartIndex <= toIndex) {
+      this.router.navigate(["/parsers", this.dragStartIndex - 1]);
+    } else if (
+      toIndex <= this.dragStartIndex &&
+      this.dragStartIndex < fromIndex
+    ) {
+      this.router.navigate(["/parsers", this.dragStartIndex + 1]);
+    } else if (this.dragStartIndex == fromIndex) {
+      this.router.navigate(["/parsers", toIndex]);
     }
   }
 
-  initializeImageMap(userConfigurations: {current: UserConfiguration, saved: UserConfiguration}[]) {
-              for (let userConfiguration of userConfigurations) {
-            let separatedValues: string[] =
-              userConfiguration.saved.configTitle.split(" - ");
-            let separatedValuesImg = separatedValues.length
-              ? separatedValues[0].replaceAll(/[\/\-\(\)\.\s]/g, "")
-              : "";
-            separatedValuesImg = separatedValuesImg
-              .replaceAll("3do", "p3do")
-              .toLowerCase();
-            let imgValue = "";
-            let alternativeValue = false;
-            let detailsValue = "";
-            try {
-              imgValue = require(
-                `../../assets/systems/${separatedValuesImg}.svg`,
-              );
-              detailsValue = userConfiguration.saved.configTitle
-                .split(" - ")
-                .slice(1)
-                .join(" - ");
-            } catch (e) {
-              alternativeValue = true;
-              detailsValue = userConfiguration.saved.configTitle;
-            }
-            this.imageMap[userConfiguration.saved.parserId] = {
-              alternative: alternativeValue,
-              details: detailsValue,
-              img: imgValue,
-            };
-          }
+  initializeImageMap(
+    userConfigurations: {
+      current: UserConfiguration;
+      saved: UserConfiguration;
+    }[],
+  ) {
+    for (let userConfiguration of userConfigurations) {
+      let separatedValues: string[] =
+        userConfiguration.saved.configTitle.split(" - ");
+      let separatedValuesImg = separatedValues.length
+        ? separatedValues[0].replaceAll(/[\/\-\(\)\.\s]/g, "")
+        : "";
+      separatedValuesImg = separatedValuesImg
+        .replaceAll("3do", "p3do")
+        .toLowerCase();
+      let imgValue = "";
+      let alternativeValue = false;
+      let detailsValue = "";
+      try {
+        imgValue = require(`../../assets/systems/${separatedValuesImg}.svg`);
+        detailsValue = userConfiguration.saved.configTitle
+          .split(" - ")
+          .slice(1)
+          .join(" - ");
+      } catch (e) {
+        alternativeValue = true;
+        detailsValue = userConfiguration.saved.configTitle;
+      }
+      this.imageMap[userConfiguration.saved.parserId] = {
+        alternative: alternativeValue,
+        details: detailsValue,
+        img: imgValue,
+      };
+    }
   }
 
   ngOnDestroy() {

--- a/src/renderer/components/nav.component.ts
+++ b/src/renderer/components/nav.component.ts
@@ -36,7 +36,6 @@ export class NavComponent implements OnDestroy {
 
   @Input() navClick: EventEmitter<any>;
 
-
   constructor(
     private parsersService: ParsersService,
     private languageService: LanguageService,

--- a/src/renderer/components/preview.component.ts
+++ b/src/renderer/components/preview.component.ts
@@ -432,13 +432,16 @@ export class PreviewComponent implements OnDestroy {
 
   async addLocalImages(app: PreviewDataApp, artworkType?: ArtworkType) {
     const options: Electron.OpenDialogSyncOptions = {
-      properties: ["multiSelections","openFile"],
+      properties: ["multiSelections", "openFile"],
       title: "Choose selections folder location.",
-      filters: [{name: "Images", extensions: ["png","tga","jpg","jpeg","webp"]}]
+      filters: [
+        { name: "Images", extensions: ["png", "tga", "jpg", "jpeg", "webp"] },
+      ],
     };
     const actualArtworkType = this.getActualArtworkType(artworkType);
-    const {filePaths}: OpenDialogReturnValue = await dialog.showOpenDialog(options);
-    if(filePaths!==undefined) {
+    const { filePaths }: OpenDialogReturnValue =
+      await dialog.showOpenDialog(options);
+    if (filePaths !== undefined) {
       let extRegex = /png|tga|jpg|jpeg|webp/i;
       for (let i = 0; i < filePaths.length; i++) {
         if (extRegex.test(path.extname(filePaths[i]))) {
@@ -454,7 +457,12 @@ export class PreviewComponent implements OnDestroy {
             "manual",
           );
           this.updateListImageRanges(app);
-          this.previewService.setImageIndex(app, this.listImagesRanges["manual"].end - 1,actualArtworkType,true)
+          this.previewService.setImageIndex(
+            app,
+            this.listImagesRanges["manual"].end - 1,
+            actualArtworkType,
+            true,
+          );
         }
       }
     }
@@ -505,7 +513,7 @@ export class PreviewComponent implements OnDestroy {
       RendererStyleFlags2.DashCase,
     );
   }
-  
+
   toggleFilters() {
     if (this.showFilters) {
       this.closeFilters();

--- a/src/renderer/components/settings.component.ts
+++ b/src/renderer/components/settings.component.ts
@@ -5,7 +5,7 @@ import {
   OnDestroy,
   Renderer2,
   RendererStyleFlags2,
-  ElementRef
+  ElementRef,
 } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import {
@@ -80,7 +80,7 @@ export class SettingsComponent implements OnDestroy {
     private activatedRoute: ActivatedRoute,
     private ipcService: IpcService,
     private renderer: Renderer2,
-    private elementRef: ElementRef
+    private elementRef: ElementRef,
   ) {
     this.currentDoc.content = this.lang.docs__md.settings.join("");
     this.activatedRoute.queryParamMap.subscribe((paramContainer: any) => {
@@ -217,7 +217,7 @@ export class SettingsComponent implements OnDestroy {
     this.languageService.loadLanguage(this.settings.language);
   }
   changeTheme(newTheme: string) {
-    if(this.settings.theme!==newTheme){
+    if (this.settings.theme !== newTheme) {
       this.settings.theme = newTheme;
       this.loadTheme();
       this.onSettingsChange();

--- a/src/renderer/components/user-exceptions.component.ts
+++ b/src/renderer/components/user-exceptions.component.ts
@@ -5,12 +5,16 @@ import {
   OnDestroy,
   Renderer2,
   ElementRef,
-  RendererStyleFlags2
+  RendererStyleFlags2,
 } from "@angular/core";
 import { ActivatedRoute, Router, RouterLinkActive } from "@angular/router";
 import { FormBuilder, FormArray, FormGroup, FormControl } from "@angular/forms";
 import { UserExceptions, SelectItem, AppSettings } from "../../models";
-import { UserExceptionsService, LoggerService, SettingsService } from "../services";
+import {
+  UserExceptionsService,
+  LoggerService,
+  SettingsService,
+} from "../services";
 import { Subscription } from "rxjs";
 import { APP } from "../../variables";
 import * as _ from "lodash";
@@ -51,9 +55,9 @@ export class ExceptionsComponent implements OnDestroy {
     private loggerService: LoggerService,
     private formBuilder: FormBuilder,
     private changeDetectorRef: ChangeDetectorRef,
-    private renderer:  Renderer2,
+    private renderer: Renderer2,
     private elementRef: ElementRef,
-    private settingsService: SettingsService
+    private settingsService: SettingsService,
   ) {
     this.appSettings = this.settingsService.getSettings();
     this.currentDoc.content = this.lang.docs__md.userExceptions.join("");

--- a/src/renderer/services/parsers.service.ts
+++ b/src/renderer/services/parsers.service.ts
@@ -12,11 +12,7 @@ import {
 import { LoggerService } from "./logger.service";
 import { FuzzyService } from "./fuzzy.service";
 import { SettingsService } from "./settings.service";
-import {
-  FileParser,
-  VariableParser,
-  ControllerManager,
-} from "../../lib";
+import { FileParser, VariableParser, ControllerManager } from "../../lib";
 import { BehaviorSubject, Subject } from "rxjs";
 import { takeWhile } from "rxjs/operators";
 import { artworkTypes } from "../../lib/artwork-types";
@@ -229,10 +225,12 @@ export class ParsersService {
   }
 
   swapIndex(fromIndex: number, toIndex: number) {
-    if(fromIndex == toIndex){return;}
+    if (fromIndex == toIndex) {
+      return;
+    }
     const configs = this.userConfigurations.getValue();
     if (fromIndex >= configs.length || toIndex >= configs.length) {
-      throw 'Index out of bounds';
+      throw "Index out of bounds";
     }
     const from = configs[fromIndex];
     configs[fromIndex] = configs[toIndex];
@@ -242,17 +240,21 @@ export class ParsersService {
   }
 
   injectIndex(fromIndex: number, toIndex: number) {
-    if (fromIndex == toIndex) {return;}
+    if (fromIndex == toIndex) {
+      return;
+    }
     const configs = this.userConfigurations.getValue();
     if (fromIndex >= configs.length || toIndex >= configs.length) {
-      throw 'Index out of bounds';
+      throw "Index out of bounds";
     }
     const from = configs[fromIndex];
-    const withoutFrom = configs.filter((_,i) => i!==fromIndex);
-    const newConfigs = withoutFrom.slice(0,toIndex).concat(from).concat(withoutFrom.slice(toIndex))
+    const withoutFrom = configs.filter((_, i) => i !== fromIndex);
+    const newConfigs = withoutFrom
+      .slice(0, toIndex)
+      .concat(from)
+      .concat(withoutFrom.slice(toIndex));
     this.userConfigurations.next(newConfigs);
     this.saveUserConfigurations();
-    
   }
 
   changeEnabledStatus(parserId: string, enabled: boolean): Promise<void> {
@@ -395,8 +397,9 @@ export class ParsersService {
       case "steamCategories":
         return null;
       case "executable":
-        const isDir = os.type() == 'Darwin' ? undefined : false;
-        return !(data || {}).path || this.validateEnvironmentPath(data.path, isDir)
+        const isDir = os.type() == "Darwin" ? undefined : false;
+        return !(data || {}).path ||
+          this.validateEnvironmentPath(data.path, isDir)
           ? null
           : this.lang.validationErrors.executable__md;
       case "romDirectory":
@@ -434,7 +437,7 @@ export class ParsersService {
                 return null;
               }
               let isDir: boolean;
-              if(os.type()=='Darwin') {
+              if (os.type() == "Darwin") {
                 isDir = inputInfo.inputType == "dir" ? true : undefined;
               } else {
                 isDir = inputInfo.inputType == "dir" ? true : false;

--- a/src/renderer/styles/logger.component.scss
+++ b/src/renderer/styles/logger.component.scss
@@ -37,9 +37,6 @@
         margin-right: 1em;
       }
     }
-
-
-
   }
   .bugreport {
     grid-area: bugreport;
@@ -195,7 +192,8 @@
     border: solid 0.5em transparent;
     background-color: var(--color-logger-menu-background);
 
-    .lowerLeft>div,.lowerRight>div {
+    .lowerLeft > div,
+    .lowerRight > div {
       @include toggleButtonColor(click-button);
       @include button();
 

--- a/src/renderer/styles/nav-link.component.scss
+++ b/src/renderer/styles/nav-link.component.scss
@@ -28,7 +28,8 @@ nav-link {
     img {
       // calculated using https://isotropic.co/tool/hex-color-to-css-filter/
       // target was #fbfd81
-      filter: sepia(20%) saturate(7471%) hue-rotate(315deg) brightness(124%) contrast(98%);
+      filter: sepia(20%) saturate(7471%) hue-rotate(315deg) brightness(124%)
+        contrast(98%);
     }
   }
 }

--- a/src/renderer/styles/nav-parsers.component.scss
+++ b/src/renderer/styles/nav-parsers.component.scss
@@ -36,7 +36,7 @@
           opacity: 0.5;
         }
         &.active {
-          background-color: var(--color-nav-link-background-active)
+          background-color: var(--color-nav-link-background-active);
         }
       }
     }
@@ -122,9 +122,9 @@
       nav-link:not(.titlelink) {
         padding: var(--padding-nav-link);
         padding-left: calc(var(--padding-nav-link) + 14px);
-  
+
         position: relative;
-  
+
         &::before {
           top: 50%;
           position: absolute;
@@ -136,66 +136,66 @@
           margin-left: var(--nav-link-before-margin-left);
           transform: translateY(-50%);
         }
-  
+
         &:hover {
           &::before {
             background-color: var(--color-nav-link-enabled-hover);
           }
-  
+
           &.active {
             &::before {
               background-color: var(--color-nav-link-enabled-active);
             }
           }
         }
-  
+
         &.active {
           &::before {
             background-color: var(--color-nav-link-enabled-active);
           }
         }
-  
+
         &.disabled {
           &::before {
             background-color: var(--color-nav-link-disabled);
           }
-  
+
           &:hover {
             &::before {
               background-color: var(--color-nav-link-disabled-hover);
             }
-  
+
             &.active {
               &::before {
                 background-color: var(--color-nav-link-disabled-active);
               }
             }
           }
-  
+
           &.active {
             &::before {
               background-color: var(--color-nav-link-disabled-active);
             }
           }
         }
-  
+
         &.unsaved {
           &::before {
             background-color: var(--color-nav-link-unsaved);
           }
-  
+
           &:hover {
             &::before {
               background-color: var(--color-nav-link-unsaved-hover);
             }
-  
+
             &.active {
               &::before {
                 background-color: var(--color-nav-link-unsaved-active);
               }
             }
           }
-  
+
           &.active {
             &::before {
               background-color: var(--color-nav-link-unsaved-active);

--- a/src/renderer/styles/settings.component.scss
+++ b/src/renderer/styles/settings.component.scss
@@ -130,7 +130,8 @@
     border: 0.5em solid transparent;
     background-color: var(--color-parsers-menu-background);
 
-    .lowerLeft>div,.lowerRight>div {
+    .lowerLeft > div,
+    .lowerRight > div {
       @include clickButtonColor(click-button, true);
       @include button();
       margin: 0 0.25em;

--- a/src/renderer/styles/themes.global.scss
+++ b/src/renderer/styles/themes.global.scss
@@ -1062,7 +1062,7 @@
   --color-ng-select-background: #33373c;
   --color-ng-select-background-active: #f5f5f5;
   --color-ng-select-background-hover: #f5f5f5;
-  --color-ng-select-section-background: var(--color-ng-select-background);;
+  --color-ng-select-section-background: var(--color-ng-select-background);
   --color-ng-select-border: transparent;
   --color-ng-select-border-active: transparent;
   --color-ng-select-border-hover: transparent;
@@ -1441,7 +1441,7 @@
   --color-nav-link-enabled-hover: var(--color--filled);
   --color-nav-link-disabled: var(--color--missing);
   --color-nav-link-disabled-active: var(--color--missing);
-  --color-nav-link-disabled-hover:var(--color--missing);
+  --color-nav-link-disabled-hover: var(--color--missing);
   --color-nav-link-unsaved: var(--color-nested-form-error-border);
   --color-nav-link-unsaved-active: var(--color-nested-form-error-border);
   --color-nav-link-unsaved-hover: var(--color-nested-form-error-border);

--- a/src/renderer/styles/user-exceptions.component.scss
+++ b/src/renderer/styles/user-exceptions.component.scss
@@ -159,7 +159,8 @@
     border: 0.5em solid transparent;
     background-color: var(--color-parsers-menu-background);
 
-    .lowerLeft>div,.lowerRight>div {
+    .lowerLeft > div,
+    .lowerRight > div {
       @include clickButtonColor(click-button, true);
       @include button();
       margin: 0 0.25em;

--- a/src/renderer/styles/view.component.scss
+++ b/src/renderer/styles/view.component.scss
@@ -221,7 +221,8 @@
     border: 0.5em solid transparent;
     background-color: var(--color-parsers-menu-background);
 
-    .lowerLeft>div,.lowerRight>div {
+    .lowerLeft > div,
+    .lowerRight > div {
       @include clickButtonColor(click-button, true);
       @include button();
       margin: 0 0.25em;

--- a/src/renderer/templates/logger.component.html
+++ b/src/renderer/templates/logger.component.html
@@ -18,7 +18,7 @@
     <span>No messages are available</span>
   </div>
 </ng-template>
-@if(showReporter) {
+@if (showReporter) {
   <div class="bugreport">
     <div [formGroup]="bugForm">
       <div class="inputContainer">
@@ -65,7 +65,9 @@
           <div class="submit" (click)="submitReport()">Submit Report</div>
         </div>
         <div class="inlineLeft" [class.hidden]="this.reportID == undefined">
-          <div class="reportIDLabel" style="margin-right: 0.25em">Report ID:</div>
+          <div class="reportIDLabel" style="margin-right: 0.25em">
+            Report ID:
+          </div>
           <div class="reportID">{{ this.reportID }}</div>
           <div class="copy" (click)="copyReportID()">
             <svg copy-icon title="Copy Report ID to clipboard"></svg>
@@ -85,8 +87,8 @@
   </div>
   <markdown class="bugreportdocs" [content]="this.explanation"></markdown>
 }
-@if(showOptions) {
-  <div class="options" >
+@if (showOptions) {
+  <div class="options">
     <div class="optionsGroup">
       <div class="optionsLabel">
         <span>Log Filters</span>
@@ -96,7 +98,7 @@
         [class.active]="settings.showErrors"
         (click)="settings.showErrors = !settings.showErrors"
       >
-      {{ lang.error }}
+        {{ lang.error }}
       </div>
       <div
         class="optionsButton"
@@ -125,21 +127,20 @@
         <span>Log Settings</span>
       </div>
       <div
-      class="optionsButton"
-      [class.active]="settings.textWrap"
-      (click)="settings.textWrap = !settings.textWrap"
-    >
-      {{ lang.textWrap }}
+        class="optionsButton"
+        [class.active]="settings.textWrap"
+        (click)="settings.textWrap = !settings.textWrap"
+      >
+        {{ lang.textWrap }}
+      </div>
+      <div
+        class="optionsButton"
+        [class.active]="settings.autoscroll"
+        (click)="settings.autoscroll = !settings.autoscroll"
+      >
+        {{ lang.autoscroll }}
+      </div>
     </div>
-    <div
-      class="optionsButton"
-      [class.active]="settings.autoscroll"
-      (click)="settings.autoscroll = !settings.autoscroll"
-    >
-      {{ lang.autoscroll }}
-    </div>
-    </div>
-
   </div>
 }
 
@@ -149,21 +150,21 @@
     <div (click)="toggleOptions()">Options</div>
   </div>
   <div class="lowerRight">
-    @if(showReporter) {
-      <div class="dangerousButton" (click)="closeReporter()">Close Reporter</div>
-    }
-    @else {
+    @if (showReporter) {
+      <div class="dangerousButton" (click)="closeReporter()">
+        Close Reporter
+      </div>
+    } @else {
       <div (click)="openReporter()">Report Bug</div>
     }
-    @if(appSettings.theme=='EmuDeck') {
+    @if (appSettings.theme == "EmuDeck") {
       <div
-      routerLink="/parsers-list"
-      routerLinkActive="active"
-      [routerLinkActiveOptions]="{ exact: true }"
-    >
-      Back
-    </div>
+        routerLink="/parsers-list"
+        routerLinkActive="active"
+        [routerLinkActiveOptions]="{ exact: true }"
+      >
+        Back
+      </div>
     }
   </div>
-
 </div>

--- a/src/renderer/templates/nav-parsers.component.html
+++ b/src/renderer/templates/nav-parsers.component.html
@@ -1,6 +1,6 @@
 <div class="parsers" [formGroup]="navForm" *ngIf="!!navForm">
   <nav-expand routerLinkActive="active">
-    @if(userConfigurations.length) {
+    @if (userConfigurations.length) {
       <div class="title">
         <div class="inputContainer">
           <div class="inlineGroup">
@@ -18,81 +18,86 @@
     }
 
     @let parserControls = getParserControls();
-    @for(userConfiguration of userConfigurations; track userConfiguration.saved.parserId; let i=$index) {
+    @for (
+      userConfiguration of userConfigurations;
+      track userConfiguration.saved.parserId;
+      let i = $index
+    ) {
       @let parserId = userConfiguration.saved.parserId;
       @let toggle = parserControls[parserId];
       <div
-      class="item"
-      [ngClass]="{
-        unsaved: userConfiguration.current != null,
-        disabled: userConfiguration.saved.disabled,
-      }">
-      @if(appSettings.theme=="EmuDeck") {
-        <div
-        class="inputContainer"
-        (click)="emuClick(toggle)">
-          <div class="inlineGroup">
-            <nav-link
-              class="parserlink"
-              [ngClass]="{
-                unsaved: userConfiguration.current != null,
-                disabled: userConfiguration.saved.disabled,
-              }"
-              [routerLink]="['/parsers', i]"
-              routerLinkActive="active"
-              [routerLinkActiveOptions]="{ exact: true }"
+        class="item"
+        [ngClass]="{
+          unsaved: userConfiguration.current != null,
+          disabled: userConfiguration.saved.disabled,
+        }"
+      >
+        @if (appSettings.theme == "EmuDeck") {
+          <div class="inputContainer" (click)="emuClick(toggle)">
+            <div class="inlineGroup">
+              <nav-link
+                class="parserlink"
+                [ngClass]="{
+                  unsaved: userConfiguration.current != null,
+                  disabled: userConfiguration.saved.disabled,
+                }"
+                [routerLink]="['/parsers', i]"
+                routerLinkActive="active"
+                [routerLinkActiveOptions]="{ exact: true }"
+              >
+                <div>
+                  <p>
+                    @if (imageMap[parserId]) {
+                      <img width="120" src="{{ imageMap[parserId].img }}" />
+                    }
+                    <span *ngIf="imageMap[parserId].alternative"
+                      >Non-EmuDeck</span
+                    >
+                  </p>
+                  <small>{{ imageMap[parserId].details }}</small>
+                </div>
+              </nav-link>
+            </div>
+          </div>
+        } @else {
+          <div
+            mwlDroppable
+            (drop)="handleDrop($event.dropData.fromIndex, i)"
+            dragOverClass="drop-over-active"
+            class="reorderer"
+          >
+            <div
+              class="inputContainer"
+              [class.active]="currentId == parserId"
+              mwlDraggable
+              dragActiveClass="drag-active"
+              showOriginalElementWhileDragging="true"
+              (dragStart)="dragStart($event)"
+              [dropData]="{ fromIndex: i }"
             >
-              <div>
-                <p>
-                  @if(imageMap[parserId]) {
-                    <img width="120" src="{{imageMap[parserId].img}}"/>
-                  }
-                  <span *ngIf="imageMap[parserId].alternative">Non-EmuDeck</span>
-                </p>
-                <small>{{imageMap[parserId].details}}</small>
+              <div class="inlineGroup">
+                <nav-link
+                  class="parserlink"
+                  [ngClass]="{
+                    unsaved: userConfiguration.current != null,
+                    disabled: userConfiguration.saved.disabled,
+                    active: currentId == parserId,
+                  }"
+                  (click)="onClick(i, parserId)"
+                >
+                  <div>
+                    {{ userConfiguration.saved.configTitle || lang.noTitle }}
+                  </div>
+                </nav-link>
+                <ng-toggle-button
+                  class="ngToggleButton"
+                  [formControl]="toggle"
+                ></ng-toggle-button>
               </div>
-            </nav-link>
+            </div>
           </div>
-        </div>
-      }
-      @else {
-        <div 
-        mwlDroppable (drop)="handleDrop($event.dropData.fromIndex, i)"
-        dragOverClass="drop-over-active"
-        class="reorderer">
-        <div
-        class="inputContainer"
-        [class.active]="currentId == parserId"
-        mwlDraggable
-        dragActiveClass="drag-active"
-        showOriginalElementWhileDragging="true"
-        (dragStart)="dragStart($event)"
-
-        [dropData]="{fromIndex: i}"
-        >
-          <div class="inlineGroup">
-            <nav-link
-              class="parserlink"
-              [ngClass]="{
-                unsaved: userConfiguration.current != null,
-                disabled: userConfiguration.saved.disabled,
-                active: currentId == parserId
-              }"
-              (click)="onClick(i, parserId)"
-            >
-              <div>{{ userConfiguration.saved.configTitle || lang.noTitle }}</div>
-            </nav-link>
-            <ng-toggle-button
-              class="ngToggleButton"
-              [formControl]="toggle"
-            ></ng-toggle-button>
-          </div>
-        </div>
-        </div>
-      }
+        }
       </div>
     }
-
-
   </nav-expand>
 </div>

--- a/src/renderer/templates/nav.component.html
+++ b/src/renderer/templates/nav.component.html
@@ -47,11 +47,11 @@
     [routerLinkActiveOptions]="{ exact: true }"
     (click)="navClick.emit()"
   >
-  <ng-container>
-    <img src="/assets/images/danger.png" alt="Icon" height="16"/>{{
-      lang.userExceptions
-    }}
-  </ng-container>
+    <ng-container>
+      <img src="/assets/images/danger.png" alt="Icon" height="16" />{{
+        lang.userExceptions
+      }}
+    </ng-container>
   </nav-link>
 </nav-expand>
 

--- a/src/renderer/templates/navarea.component.html
+++ b/src/renderer/templates/navarea.component.html
@@ -1,6 +1,2 @@
 <nav [navClick]="navClick"></nav>
-<nav-parsers 
-    mwlDraggableScrollContainer
-    [navClick]="navClick"
-    >
-</nav-parsers>
+<nav-parsers mwlDraggableScrollContainer [navClick]="navClick"> </nav-parsers>

--- a/src/renderer/templates/preview.component.html
+++ b/src/renderer/templates/preview.component.html
@@ -22,8 +22,8 @@
     </ol>
 
     <p>
-      If a game has the wrong art hit <strong>Fix</strong> and select the correct game,
-      then hit <strong>Save and close</strong>
+      If a game has the wrong art hit <strong>Fix</strong> and select the
+      correct game, then hit <strong>Save and close</strong>
     </p>
     <p>
       If you don't want to add all games click <strong>Exclude Apps</strong> and

--- a/src/renderer/templates/settings.component.html
+++ b/src/renderer/templates/settings.component.html
@@ -1,4 +1,4 @@
-@if(showMarkdown) {
+@if (showMarkdown) {
   <markdown class="docs" [content]="this.currentDoc.content"></markdown>
 }
 <choose-accounts
@@ -55,7 +55,7 @@
           style="font-size: 0.85em"
           class="ngSelect"
           [ngModel]="settings.theme"
-          (ngModelChange)="changeTheme($event);"
+          (ngModelChange)="changeTheme($event)"
           [values]="themes"
         >
         </ng-select>
@@ -202,7 +202,6 @@
       </div>
     </div>
   </div>
-
 
   <div>
     <div class="section">
@@ -518,16 +517,15 @@
 </div>
 <div class="menu" drag-scroll>
   <div class="lowerLeft">
-    @if(settings.environmentVariables.steamDirectory) {
+    @if (settings.environmentVariables.steamDirectory) {
       <div (click)="steamDir()">{{ lang.text.steamDir }}</div>
     }
     <div (click)="configDir()">{{ lang.text.configDir }}</div>
   </div>
   <div class="lowerRight">
-    @if(showMarkdown) {
+    @if (showMarkdown) {
       <div (click)="closeDocs()" class="dangerousButton">Close Docs</div>
-    }
-    @else {
+    } @else {
       <div (click)="openDocs()">Open Docs</div>
     }
   </div>

--- a/src/renderer/templates/user-exceptions.component.html
+++ b/src/renderer/templates/user-exceptions.component.html
@@ -23,7 +23,7 @@
     [(ngModel)]="filterValue"
   ></ng-text-input>
 </div>
-@if(showMarkdown) {
+@if (showMarkdown) {
   <markdown class="docs" [content]="this.currentDoc.content"></markdown>
 }
 <div class="userExceptions">
@@ -140,21 +140,19 @@
     </div>
   </div>
   <div class="lowerRight">
-    @if(appSettings.theme=='EmuDeck'){
+    @if (appSettings.theme == "EmuDeck") {
       <nav-link
-      [routerLink]="['/parsers-list']"
-      routerLinkActive="active"
-      [routerLinkActiveOptions]="{ exact: true }"
-      >Back</nav-link>
-    }
-    @else {
-      @if(showMarkdown) {
+        [routerLink]="['/parsers-list']"
+        routerLinkActive="active"
+        [routerLinkActiveOptions]="{ exact: true }"
+        >Back</nav-link
+      >
+    } @else {
+      @if (showMarkdown) {
         <div (click)="closeDocs()" class="dangerousButton">Close Docs</div>
-      }
-      @else {
+      } @else {
         <div (click)="openDocs()">Open Docs</div>
       }
     }
   </div>
-
 </div>

--- a/src/renderer/templates/view.component.html
+++ b/src/renderer/templates/view.component.html
@@ -149,18 +149,18 @@
     <div (click)="refreshGames(true)">Refresh Games</div>
   </div>
   <div class="lowerRight">
-    @if(!!currentShortcut) {
+    @if (!!currentShortcut) {
       <div class="launch" (click)="launchTitle()">Launch Title</div>
     }
-    @if(appSettings.theme == 'EmuDeck') {
+    @if (appSettings.theme == "EmuDeck") {
       <div
-      class="menuButton"
-      routerLink="/parsers-list"
-      routerLinkActive="active"
-      [routerLinkActiveOptions]="{ exact: true }"
-    >
-      Back
-    </div>
+        class="menuButton"
+        routerLink="/parsers-list"
+        routerLinkActive="active"
+        [routerLinkActiveOptions]="{ exact: true }"
+      >
+        Back
+      </div>
     }
   </div>
 </div>


### PR DESCRIPTION
Turns out the maintainers know their codebase better than I do - who knew!

Per reviewer feedback, this reverts some overly ambitious changes from PR 761 while keeping the essential cloud storage fix that resolves the 'Key not found in database' error.

Specific changes based on comments:
- Restore LevelDB operations for backwards compatibility (cbartondock's suggestion)
- Revert to v2.5.29 category naming with simple base64 encoding
- Remove category fallback logic - users intentionally add uncategorized games (kencinder's point)
- Keep cloud storage namespace detection and writing for modern Steam

The result: works with both old and new Steam, doesn't make assumptions about user intent.