### PR TITLE
Exclude steamdeck-input-disabler from steam is running check

### DIFF
--- a/src/lib/category-manager.ts
+++ b/src/lib/category-manager.ts
@@ -69,9 +69,11 @@ export class CategoryManager {
           'steam rom manager',
           'steamos-',           // SteamOS system services (steamos-manager, steamos_log_submitter, etc.)
           'steamgriddb',        // Decky plugin
+          'steamdeck-input-disabler', // decky plugin
           'sddm',               // Display manager
           '/usr/lib/steamos',   // SteamOS system paths
           '/usr/bin/python',    // Python scripts (steamos_log_submitter)
+
         ];
 
         return !excludePatterns.some(pattern => lower.includes(pattern));


### PR DESCRIPTION
Excludes steamdeck-input-disabler from the "is steam running" check. See https://github.com/SteamGridDB/steam-rom-manager/issues/768

steamdeck-input-disabler is a fairly common plugin for disabling the steam controller while other controllers are connected, 