### PR TITLE
Fixing Ubisoft Connect Parser

### DIFF
--- a/src/lib/parsers/uplay.parser.ts
+++ b/src/lib/parsers/uplay.parser.ts
@@ -122,17 +122,26 @@ export class UPlayParser implements GenericParser {
         //   resolve({});
         // })
       }
-      if (!fs.existsSync(ubisoftDir)) {
-        return reject(this.lang.errors.uplayDirNotFound);
-      }
-      let configPath = path.join(
-        ubisoftDir,
-        "Ubisoft Game Launcher",
-        "cache",
-        "configuration",
-        "configurations",
-      );
-      if (!fs.existsSync(configPath)) {
+      const localAppData =
+        process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local");
+      const candidateConfigPaths = [
+        path.join(
+          localAppData,
+          "Ubisoft Game Launcher",
+          "cache",
+          "configuration",
+          "configurations",
+        ),
+        path.join(
+          ubisoftDir,
+          "Ubisoft Game Launcher",
+          "cache",
+          "configuration",
+          "configurations",
+        ),
+      ];
+      const configPath = candidateConfigPaths.find((p) => fs.existsSync(p));
+      if (!configPath) {
         return reject(this.lang.errors.uplayNotInstalled);
       }
 


### PR DESCRIPTION
fixes #751 by adjusting the Parser to the new paths while also trying to keep the thing backwards compatible. 

New Paths work, backwards compatibility is untested because I dont have the old version installed anywhere.