### PR TITLE
Fix funding configuration location

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,3 @@
 github: cbartondock
 buy_me_a_coffee: cbartondock
 patreon: SteamROMManager
-polar: SteamGridDB


### PR DESCRIPTION
## Summary
- Move the funding config to `.github/FUNDING.yml`, which is the location GitHub reads for the repository Sponsor button.
- Remove the Polar entry because `https://polar.sh/SteamGridDB` currently returns 404.
- Keep the existing GitHub Sponsors, Buy Me a Coffee, and Patreon entries intact.

Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository

## Verification
- `curl -s -L --max-time 8 -o /dev/null -w "%{http_code}" https://polar.sh/SteamGridDB` returns `404`
- `git diff --check`