### PR TITLE
Create Sony PlayStation 4.json

### DIFF
--- a/files/presets/Sony PlayStation 4.json
+++ b/files/presets/Sony PlayStation 4.json
@@ -1,0 +1,97 @@
+[
+    {
+        "parserType": "Glob",
+        "configTitle": "Sony PlayStation 4 - shadPS4",
+        "steamDirectory": "${steamdirglobal}",
+        "romDirectory": "[path-to-roms]",
+        "steamCategories": [
+            "PS4"
+        ],
+        "executableArgs": "-g \"${filePath}\" -f true",
+        "executableModifier": "\"${exePath}\"",
+        "startInDirectory": "",
+        "titleModifier": "${fuzzyTitle}",
+        "fetchControllerTemplatesButton": null,
+        "removeControllersButton": null,
+        "steamInputEnabled": "2",
+        "imageProviders": [
+            "sgdb"
+        ],
+        "onlineImageQueries": [
+            "${fuzzyTitle}"
+        ],
+        "imagePool": "${fuzzyTitle}",
+        "drmProtect": false,
+        "userAccounts": {
+            "specifiedAccounts": [
+                "Global"
+            ]
+        },
+        "parserInputs": {
+            "glob": "${title}/@(eboot.bin|EBOOT.BIN)"
+        },
+        "executable": {
+            "path": "path-to-emu",
+            "shortcutPassthrough": false,
+            "appendArgsToExecutable": true
+        },
+        "titleFromVariable": {
+            "limitToGroups": [
+                "PS4"
+            ],
+            "caseInsensitiveVariables": false,
+            "skipFileIfVariableWasNotFound": false
+        },
+        "fuzzyMatch": {
+            "replaceDiacritics": true,
+            "removeCharacters": true,
+            "removeBrackets": true
+        },
+        "controllers": {
+            "ps4": null,
+            "ps5": null,
+            "ps5_edge": null,
+            "xbox360": null,
+            "xboxone": null,
+            "xboxelite": null,
+            "switch_joycon_left": null,
+            "switch_joycon_right": null,
+            "switch_pro": null,
+            "neptune": null,
+            "steamcontroller_gordon": null
+        },
+        "imageProviderAPIs": {
+            "sgdb": {
+                "nsfw": true,
+                "humor": false,
+                "styles": [],
+                "stylesHero": [],
+                "stylesLogo": [],
+                "stylesIcon": [],
+                "imageMotionTypes": [
+                    "static"
+                ],
+                "sizes": [],
+                "sizesHero": [],
+                "sizesTall": null,
+                "sizesIcon": []
+            }
+        },
+        "defaultImage": {
+            "tall": null,
+            "long": null,
+            "hero": null,
+            "logo": null,
+            "icon": null
+        },
+        "localImages": {
+            "tall": null,
+            "long": null,
+            "hero": null,
+            "logo": null,
+            "icon": null
+        },
+        "parserId": "178272980487670731",
+        "version": 25
+    }
+]

--- a/files/presets/Sony PlayStation 4.json
+++ b/files/presets/Sony PlayStation 4.json
@@ -1,97 +1,76 @@
-[
-    {
-        "parserType": "Glob",
-        "configTitle": "Sony PlayStation 4 - shadPS4",
-        "steamDirectory": "${steamdirglobal}",
-        "romDirectory": "[path-to-roms]",
-        "steamCategories": [
-            "PS4"
-        ],
-        "executableArgs": "-g \"${filePath}\" -f true",
-        "executableModifier": "\"${exePath}\"",
-        "startInDirectory": "",
-        "titleModifier": "${fuzzyTitle}",
-        "fetchControllerTemplatesButton": null,
-        "removeControllersButton": null,
-        "steamInputEnabled": "2",
-        "imageProviders": [
-            "sgdb"
-        ],
-        "onlineImageQueries": [
-            "${fuzzyTitle}"
-        ],
-        "imagePool": "${fuzzyTitle}",
-        "drmProtect": false,
-        "userAccounts": {
-            "specifiedAccounts": [
-                "Global"
-            ]
-        },
-        "parserInputs": {
-            "glob": "${title}/@(eboot.bin|EBOOT.BIN)"
-        },
-        "executable": {
-            "path": "path-to-emu",
-            "shortcutPassthrough": false,
-            "appendArgsToExecutable": true
-        },
-        "titleFromVariable": {
-            "limitToGroups": [
-                "PS4"
-            ],
-            "caseInsensitiveVariables": false,
-            "skipFileIfVariableWasNotFound": false
-        },
-        "fuzzyMatch": {
-            "replaceDiacritics": true,
-            "removeCharacters": true,
-            "removeBrackets": true
-        },
-        "controllers": {
-            "ps4": null,
-            "ps5": null,
-            "ps5_edge": null,
-            "xbox360": null,
-            "xboxone": null,
-            "xboxelite": null,
-            "switch_joycon_left": null,
-            "switch_joycon_right": null,
-            "switch_pro": null,
-            "neptune": null,
-            "steamcontroller_gordon": null
-        },
-        "imageProviderAPIs": {
-            "sgdb": {
-                "nsfw": true,
-                "humor": false,
-                "styles": [],
-                "stylesHero": [],
-                "stylesLogo": [],
-                "stylesIcon": [],
-                "imageMotionTypes": [
-                    "static"
-                ],
-                "sizes": [],
-                "sizesHero": [],
-                "sizesTall": null,
-                "sizesIcon": []
-            }
-        },
-        "defaultImage": {
-            "tall": null,
-            "long": null,
-            "hero": null,
-            "logo": null,
-            "icon": null
-        },
-        "localImages": {
-            "tall": null,
-            "long": null,
-            "hero": null,
-            "logo": null,
-            "icon": null
-        },
-        "parserId": "178272980487670731",
-        "version": 25
-    }
-]
+{
+  "Sony PlayStation 4 - shadPS4": {
+    "parserType": "Glob",
+    "configTitle": "Sony PlayStation 4 - shadPS4",
+    "executableModifier": "\"${exePath}\"",
+    "romDirectory": "[path-to-roms]",
+    "steamDirectory": "${steamdirglobal}",
+    "startInDirectory": "",
+    "titleModifier": "${fuzzyTitle}",
+    "executableArgs": "-g \"${filePath}\" -f true",
+    "onlineImageQueries": ["${fuzzyTitle}"],
+    "imagePool": "${fuzzyTitle}",
+    "imageProviders": ["sgdb"],
+    "disabled": false,
+    "userAccounts": {
+      "specifiedAccounts": ["Global"]
+    },
+    "parserInputs": {
+      "glob": "${title}/@(eboot.bin|EBOOT.BIN)"
+    },
+    "titleFromVariable": {
+      "caseInsensitiveVariables": false,
+      "skipFileIfVariableWasNotFound": false,
+      "limitToGroups": ["PS4"]
+    },
+    "fuzzyMatch": {
+      "replaceDiacritics": true,
+      "removeCharacters": true,
+      "removeBrackets": true
+    },
+    "executable": {
+      "path": "[path-to-emu]",
+      "shortcutPassthrough": false,
+      "appendArgsToExecutable": true
+    },
+    "imageProviderAPIs": {
+      "sgdb": {
+        "nsfw": true,
+        "humor": false,
+        "imageMotionTypes": ["static"],
+        "styles": [],
+        "stylesHero": [],
+        "stylesLogo": [],
+        "stylesIcon": []
+      },
+      "steamCDN": {}
+    },
+    "controllers": {
+      "ps4": null,
+      "ps5": null,
+      "xbox360": null,
+      "xboxone": null,
+      "switch_joycon_left": null,
+      "switch_joycon_right": null,
+      "switch_pro": null,
+      "neptune": null
+    },
+    "defaultImage": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "localImages": {
+      "long": "",
+      "tall": "",
+      "hero": "",
+      "logo": "",
+      "icon": ""
+    },
+    "steamInputEnabled": "1",
+    "drmProtect": false,
+    "steamCategories": ["PS4"]
+  }
+}


### PR DESCRIPTION
Proposal for a PS4/shadPS4 preset.
I have replaced system-specific paths with placeholders in square brackets.

Two issues:

1) artwork is picked up correctly, but not automatically. I had to do Fix-Save-Reset-Save for each game.

2) shadPS4 wants title updates in their own directory. They usually (always?) contain an executable file that matches the given pattern, so title updates are picked up as duplicates of the main game.

Other than that, things seems to work and I was able to add a game to Steam and launch it in Big Picture.

credit to @andshrew for the TitleID list and to @reinaldo110 for doing work on the preset.