### PR TITLE
fix: improve steamCDN artwork retrieval logic

### DIFF
--- a/src/lib/artwork-types/available-artwork-types.ts
+++ b/src/lib/artwork-types/available-artwork-types.ts
@@ -40,16 +40,11 @@ export const artworkSingDict: Record<ArtworkType, string> = {
   icon: "icon",
 };
 
-export const steamArtworkDict: Record<ArtworkType, string[]> = {
-  tall: ["library_600x900_2x.jpg", "library_600x900.jpg"],
-  long: ["library_header_2x.jpg", "header_2x.jpg", "header.jpg", "capsule_616x353.jpg", "capsule_231x87.jpg"],
-  hero: [
-    "library_hero_2x.jpg",
-    "library_hero.jpg",
-    "page_bg_generated_v6b.jpg",
-  ],
-  logo: ["logo_2x.png", "logo.png"],
-  icon: [],
+export const steamArtworkDict: Record<Exclude<ArtworkType, "icon">, string> = {
+  tall: "library_capsule_full",
+  long: "header_image_full",
+  hero: "library_hero_full",
+  logo: "library_logo_full",
 };
 
 export const artworkIdDict: Record<ArtworkType, string> = {

--- a/src/lib/image-providers/steamcdn.worker.ts
+++ b/src/lib/image-providers/steamcdn.worker.ts
@@ -10,16 +10,25 @@ import { artworkTypes, steamArtworkDict } from "../artwork-types";
 import { imageProviderNames, sgdbIdRegex } from "./available-providers";
 
 
-async function firstValidArtworkUrl(id: number, candidates: string[]): Promise<string | undefined> {
-  for (const file of candidates) {
-    const url = `https://cdn.cloudflare.steamstatic.com/steam/apps/${id}/${file}`;
-    try {
-      const res = await fetch(url, { method: "HEAD" });
-      if (res.ok) return url;
-    } catch {
-      // network error, try next candidate
-    }
+async function firstValidArtworkUrl(id: number, metadata: Record<string, any>, artworkType: keyof typeof steamArtworkDict): Promise<string | undefined> {
+
+  let file: string;
+
+  if (artworkType === "long") {
+    file = metadata["header_image_full"]["english"];
+  } else {
+    file = metadata[steamArtworkDict[artworkType]]["image2x"] ? metadata[steamArtworkDict[artworkType]]["image2x"]["english"] : metadata[steamArtworkDict[artworkType]]["image"]["english"];
   }
+
+  const url = `https://shared.steamstatic.com/store_item_assets/steam/apps/${id}/${file}`;
+
+  try {
+    const res = await fetch(url, { method: "HEAD" });
+    if (res.ok) return url;
+  } catch {
+  // network error, try next candidate
+  }
+
   return undefined;
 }
 
@@ -80,7 +89,7 @@ export class SteamCDNProvider extends GenericProvider {
                     loadStatus: "notStarted",
                   });
                 } else {
-                  const url = await firstValidArtworkUrl(id, steamArtworkDict[artworkType]);
+                  const url = await firstValidArtworkUrl(id, metadata, artworkType as keyof typeof steamArtworkDict);
                   if (url) {
                     self.proxy.image({
                       imageProvider: imageProviderNames.steamCDN,


### PR DESCRIPTION
### Description

Uses already retrieved SGDB metadata to assign correct images urls at the highest quality available 