### PR TITLE
Fix VDF writes when artwork URLs are missing

### DIFF
--- a/src/lib/vdf-screenshots-file.ts
+++ b/src/lib/vdf-screenshots-file.ts
@@ -176,6 +176,10 @@ export class VDF_ScreenshotsFile {
       ) {
         const appId = addableAppIds[j];
         const data = screenshotsData[appId] as VDF_ScreenshotItem;
+        if (typeof data.url !== "string" || data.url.length === 0) {
+          screenshotsData[appId] = data.title;
+          continue;
+        }
         const dmcaCheck = data.url.endsWith("?"); // Nintendo Sucks
         if (!dmcaCheck) {
           let ext: string = data.url


### PR DESCRIPTION
## Summary

- skip artwork downloads when a selected shortcut has no usable URL
- preserve the shortcut title so VDF serialization can finish

Fixes #824.

## Root cause

An unsuccessful artwork lookup can leave `imageUrl` undefined. The VDF writer called `endsWith()` on that value and aborted the entire write.

## Testing

- `tsc -P ./webpack`
- Prettier check for `src/lib/vdf-screenshots-file.ts`

## AI assistance

OpenAI Codex assisted with issue discovery, implementation, and validation. I reviewed the change and test results.