### PR TITLE
fix: convert ICO file extension to PNG for steam client

### DIFF
--- a/src/lib/vdf-screenshots-file.ts
+++ b/src/lib/vdf-screenshots-file.ts
@@ -187,6 +187,9 @@ export class VDF_ScreenshotsFile {
             .slice(-1)[0]
             .replace(/[^\w\s]*$/gi, "");
           ext = ids.map_ext["" + ext] || ext;
+          if (ext.toLowerCase() === "ico") {
+            ext = "png";
+          }
           const gridPath = path.join(this.gridDirectory, `${appId}.${ext}`);
           let secondaryPath: string;
           if (data.sgdbId && data.drmProtect) {


### PR DESCRIPTION
Fixes #783 

### Description

Replaces `.ico` image ext to `.png` which bypass hardwired denylist  in Steam client

Tested in Windows client but it should work in Linux as well